### PR TITLE
xml2js rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hed-validator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JavaScript validator for HED (Hierarchical Event Descriptor) strings.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "homepage": "https://github.com/hed-standard/hed-javascript",
   "dependencies": {
     "date-and-time": "^0.9.0",
-    "libxmljs": "^0.19.5",
     "request": "^2.88.0",
-    "request-promise-native": "^1.0.7"
+    "request-promise-native": "^1.0.7",
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/tests/schema.spec.js
+++ b/tests/schema.spec.js
@@ -36,14 +36,6 @@ describe('HED schemas', function() {
     hedSchemaPromise = validate.schema.buildSchema({ path: localHedSchemaFile })
   })
 
-  it("should have a root element with the name 'HED'", async done => {
-    hedSchemaPromise.then(hedSchema => {
-      const hedSchemaRootName = hedSchema.rootElement.name()
-      assert.strictEqual(hedSchemaRootName, 'HED')
-      done()
-    })
-  })
-
   it('should have tag dictionaries for all required attributes', async done => {
     const tagDictionaryKeys = [
       'default',

--- a/utils/xpath.js
+++ b/utils/xpath.js
@@ -1,0 +1,55 @@
+// Temporary XPath implementation until the xml2js-xpath package adds needed functionality.
+
+const find = function(element, query) {
+  const nodeQuery = /^\/\/(\w+)$/
+  const attributeQuery = /^\/\/(\w+)\[@(\w+)]$/
+
+  let elementName, attributeName
+
+  const attributeMatch = query.match(attributeQuery)
+  if (attributeMatch) {
+    ;[, elementName, attributeName] = attributeMatch
+  } else {
+    const nodeMatch = query.match(nodeQuery)
+    if (nodeMatch) {
+      ;[, elementName] = nodeMatch
+    } else {
+      return []
+    }
+  }
+
+  const result = []
+  const search = function(element) {
+    if (
+      attributeName === undefined ||
+      ('$' in element && attributeName in element.$)
+    ) {
+      result.push(element)
+    }
+    if (elementName in element) {
+      for (const child of element[elementName]) {
+        search(child)
+      }
+    }
+  }
+
+  if (elementName === 'unitClass') {
+    for (const unitClass of element.unitClasses[0].unitClass) {
+      result.push(unitClass)
+    }
+  } else if (elementName === 'node') {
+    if (elementName in element) {
+      for (const child of element[elementName]) {
+        search(child)
+      }
+    } else {
+      return []
+    }
+  }
+
+  return result
+}
+
+module.exports = {
+  find: find,
+}

--- a/validators/schema.js
+++ b/validators/schema.js
@@ -211,7 +211,6 @@ const tagHasAttribute = function(tag, tagAttribute) {
 }
 
 const Schema = function(rootElement, dictionaries) {
-  this.rootElement = rootElement
   this.dictionaries = dictionaries
   this.version = rootElement.attr('version').value()
   this.tagHasAttribute = tagHasAttribute

--- a/validators/schema.js
+++ b/validators/schema.js
@@ -94,7 +94,6 @@ const SchemaDictionaries = {
   populateUnitClassUnitsDictionary: function(unitClassElements) {
     this.dictionaries[unitsElement] = {}
     for (const unitClassElement of unitClassElements) {
-      //console.dir(unitClassElement)
       const elementName = this.getElementTagValue(unitClassElement)
       const elementUnits = this.getElementTagValue(
         unitClassElement,

--- a/validators/schema.js
+++ b/validators/schema.js
@@ -1,4 +1,10 @@
-const libxmljs = require('libxmljs')
+const xml2js = require('xml2js')
+
+// TODO: Switch require once upstream bugs are fixed.
+// const xpath = require('xml2js-xpath')
+// Temporary
+const xpath = require('../utils/xpath')
+
 const files = require('../utils/files')
 const arrayUtil = require('../utils/array')
 
@@ -26,10 +32,19 @@ const unitClassUnitsElement = 'units'
 const unitsElement = 'units'
 
 const SchemaDictionaries = {
+  setParent: function(node, parent) {
+    node.$parent = parent
+    if (node.node) {
+      for (const child of node.node) {
+        this.setParent(child, node)
+      }
+    }
+  },
+
   populateDictionaries: function() {
     this.dictionaries = {}
-    this.populateTagDictionaries()
     this.populateUnitClassDictionaries()
+    this.populateTagDictionaries()
     return this.dictionaries
   },
 
@@ -79,6 +94,7 @@ const SchemaDictionaries = {
   populateUnitClassUnitsDictionary: function(unitClassElements) {
     this.dictionaries[unitsElement] = {}
     for (const unitClassElement of unitClassElements) {
+      //console.dir(unitClassElement)
       const elementName = this.getElementTagValue(unitClassElement)
       const elementUnits = this.getElementTagValue(
         unitClassElement,
@@ -92,9 +108,8 @@ const SchemaDictionaries = {
     this.dictionaries[defaultUnitsForTypeAttribute] = {}
     for (const unitClassElement of unitClassElements) {
       const elementName = this.getElementTagValue(unitClassElement)
-      this.dictionaries[defaultUnitsForTypeAttribute][
-        elementName
-      ] = unitClassElement.attr(defaultUnitAttribute).value()
+      this.dictionaries[defaultUnitsForTypeAttribute][elementName] =
+        unitClassElement.$[defaultUnitAttribute]
     }
   },
 
@@ -106,9 +121,8 @@ const SchemaDictionaries = {
     this.dictionaries[attributeName] = {}
     for (let i = 0; i < tagList.length; i++) {
       const tag = tagList[i]
-      this.dictionaries[attributeName][tag.toLowerCase()] = tagElementList[i]
-        .attr(attributeName)
-        .value()
+      this.dictionaries[attributeName][tag.toLowerCase()] =
+        tagElementList[i].$[attributeName]
     }
   },
 
@@ -123,23 +137,23 @@ const SchemaDictionaries = {
   getAncestorTagNames: function(tagElement) {
     const ancestorTags = []
     let parentTagName = this.getParentTagName(tagElement)
-    let parentElement = tagElement.parent()
+    let parentElement = tagElement.$parent
     while (parentTagName) {
       ancestorTags.push(parentTagName)
       parentTagName = this.getParentTagName(parentElement)
-      parentElement = parentElement.parent()
+      parentElement = parentElement.$parent
     }
     return ancestorTags
   },
 
   getElementTagValue: function(element, tagName = 'name') {
-    return element.find(tagName)[0].text()
+    return element[tagName][0]
   },
 
   getParentTagName: function(tagElement) {
-    const parentTagElement = tagElement.parent()
+    const parentTagElement = tagElement.$parent
     if (parentTagElement && parentTagElement !== this.rootElement) {
-      return parentTagElement.find('name')[0].text()
+      return parentTagElement.name
     } else {
       return ''
     }
@@ -154,7 +168,10 @@ const SchemaDictionaries = {
 
   getTagsByAttribute: function(attributeName) {
     const tags = []
-    const tagElements = this.rootElement.find('.//node[@' + attributeName + ']')
+    const tagElements = xpath.find(
+      this.rootElement,
+      '//node[@' + attributeName + ']',
+    )
     for (const attributeTagElement of tagElements) {
       const tag = this.getTagPathFromTagElement(attributeTagElement)
       tags.push(tag)
@@ -164,7 +181,7 @@ const SchemaDictionaries = {
 
   getAllTags: function(tagElementName = 'node') {
     const tags = []
-    const tagElements = this.rootElement.find('.//' + tagElementName)
+    const tagElements = xpath.find(this.rootElement, '//' + tagElementName)
     for (const tagElement of tagElements) {
       const tag = this.getTagPathFromTagElement(tagElement)
       tags.push(tag)
@@ -174,9 +191,9 @@ const SchemaDictionaries = {
 
   getElementsByName: function(elementName = 'node', parentElement = undefined) {
     if (!parentElement) {
-      return this.rootElement.find('.//' + elementName)
+      return xpath.find(this.rootElement, '//' + elementName)
     } else {
-      return parentElement.find('.//' + elementName)
+      return xpath.find(parentElement, '//' + elementName)
     }
   },
 
@@ -212,7 +229,7 @@ const tagHasAttribute = function(tag, tagAttribute) {
 
 const Schema = function(rootElement, dictionaries) {
   this.dictionaries = dictionaries
-  this.version = rootElement.attr('version').value()
+  this.version = rootElement.$.version
   this.tagHasAttribute = tagHasAttribute
 }
 
@@ -224,7 +241,7 @@ const loadRemoteSchema = function(version) {
   return files
     .readHTTPSFile(url)
     .then(data => {
-      return libxmljs.parseXmlString(data)
+      return xml2js.parseStringPromise(data)
     })
     .catch(error => {
       throw new Error(
@@ -241,7 +258,7 @@ const loadLocalSchema = function(path) {
   return files
     .readFile(path)
     .then(data => {
-      return libxmljs.parseXmlString(data)
+      return xml2js.parseStringPromise(data)
     })
     .catch(error => {
       throw new Error(
@@ -264,7 +281,8 @@ const buildLocalSchema = function(path) {
 
 const buildSchemaObject = function(xmlData) {
   const schemaDictionaries = Object.create(SchemaDictionaries)
-  const rootElement = xmlData.root()
+  const rootElement = xmlData.HED
+  schemaDictionaries.setParent(rootElement, xmlData)
   schemaDictionaries.rootElement = rootElement
   const dictionaries = schemaDictionaries.populateDictionaries()
   return new Schema(rootElement, dictionaries)


### PR DESCRIPTION
This branch rewrites the schema parsing code to use the pure-JS xml2js library, along with a temporary kludge to parse two types of XPath queries while I'm waiting on the author of xml2js-xpath to fix several bugs that prevent me from using it here.