### PR TITLE
Implement clockTime unit class

### DIFF
--- a/tests/data/HED7.1.1.xml
+++ b/tests/data/HED7.1.1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<HED version="7.1.0">
+<HED version="7.1.1">
    <node>
       <name>Event</name>
       <node position="1" predicateType="passThrough" requireChild="true" required="true">
@@ -374,9 +374,8 @@
          <node>
             <name>Clock face</name>
             <description>Used to study things like hemispheric neglect. The tag is related to the clock-drawing-test</description>
-            <node takesValue="true" unitClass="time">
+            <node takesValue="true" unitClass="clockTime">
                <name>#</name>
-               <description>Hour:min</description>
             </node>
          </node>
       </node>
@@ -772,7 +771,7 @@
       </node>
       <node>
          <name>Imagined</name>
-         <description>This is used to identity that the (sub)event only happened in participant's imagination, e.g.  imagined movements in motor imagery paradigms.</description>
+         <description>This is used to identity that the (sub)event only happened in the imagination of the participant, e.g.  imagined movements in motor imagery paradigms.</description>
       </node>
       <node requireChild="true">
          <name>State ID</name>
@@ -1612,7 +1611,7 @@
       </node>
       <node>
          <name>Probability</name>
-         <description>Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or 'low', 'high', etc.</description>
+         <description>Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or low, high, etc.</description>
       </node>
       <node requireChild="true">
          <name>Temporal uncertainty</name>
@@ -1817,7 +1816,7 @@
          </node>
          <node>
             <name>Drop</name>
-            <description>For example something  drops from subject’s hand</description>
+            <description>For example something  drops from the hand of the subject</description>
          </node>
       </node>
       <node>
@@ -2648,7 +2647,7 @@
                   <name>Stage</name>
                   <node takesValue="true">
                      <name>#</name>
-                     <description>a number between 1 to 4, or 'REM'</description>
+                     <description>a number between 1 to 4, or REM</description>
                   </node>
                </node>
             </node>
@@ -2909,7 +2908,7 @@
          <description>Default</description>
          <node>
             <name>Clinic</name>
-            <description>Recording in a clinical setting such as in a hospital or doctor’s office</description>
+            <description>Recording in a clinical setting such as in a hospital or medical office</description>
          </node>
          <node>
             <name>Dim Room</name>
@@ -3673,10 +3672,18 @@
          <units>
             <unit SIUnit="true">second</unit>
             <unit SIUnit="true" unitSymbol="true">s</unit>
-            <unit unitSymbol="true">hour:min</unit>
             <unit>day</unit>
             <unit>minute</unit>
             <unit>hour</unit>
+         </units>
+      </unitClass>
+      <unitClass defaultUnits="hour:min">
+         <name>clockTime</name>
+         <units>
+            <unit unitSymbol="true">hour:min</unit>
+            <unit unitSymbol="true">h:m</unit>
+            <unit unitSymbol="true">hour:min:sec</unit>
+            <unit unitSymbol="true">h:m:s</unit>
          </units>
       </unitClass>
       <unitClass defaultUnits="Hz">

--- a/tests/hed.spec.js
+++ b/tests/hed.spec.js
@@ -675,6 +675,8 @@ describe('Latest HED Schema', () => {
             parsedTestString,
             schema,
             testIssues,
+            true,
+            true,
           )
         },
       )

--- a/tests/hed.spec.js
+++ b/tests/hed.spec.js
@@ -3,7 +3,7 @@ const validate = require('../validators')
 const generateIssue = require('../utils/issues')
 
 describe('Latest HED Schema', () => {
-  const hedSchemaFile = 'tests/data/HED7.1.0.xml'
+  const hedSchemaFile = 'tests/data/HED7.1.1.xml'
   let hedSchemaPromise
 
   beforeAll(() => {
@@ -508,14 +508,8 @@ describe('Latest HED Schema', () => {
         properTime: true,
         invalidTime: false,
       }
-      const legalTimeUnits = [
-        's',
-        'second',
-        'hour:min',
-        'day',
-        'minute',
-        'hour',
-      ]
+      const legalTimeUnits = ['s', 'second', 'day', 'minute', 'hour']
+      const legalClockTimeUnits = ['h:m', 'h:m:s', 'hour:min', 'hour:min:sec']
       const legalFrequencyUnits = ['Hz', 'hertz']
       const expectedIssues = {
         correctUnit: [],
@@ -555,7 +549,7 @@ describe('Latest HED Schema', () => {
         invalidTime: [
           generateIssue('unitClassInvalidUnit', {
             tag: testStrings.invalidTime,
-            unitClassUnits: legalTimeUnits.sort().join(','),
+            unitClassUnits: legalClockTimeUnits.sort().join(','),
           }),
         ],
       }

--- a/tests/schema.spec.js
+++ b/tests/schema.spec.js
@@ -1,12 +1,12 @@
 const assert = require('chai').assert
 const validate = require('../validators')
 
-const localHedSchemaFile = 'tests/data/HED7.1.0.xml'
-const localHedSchemaVersion = '7.1.0'
+const localHedSchemaFile = 'tests/data/HED7.1.1.xml'
+const localHedSchemaVersion = '7.1.1'
 
 describe('Remote HED schemas', function() {
   it('can be loaded from a central GitHub repository', () => {
-    const remoteHedSchemaVersion = '7.1.0'
+    const remoteHedSchemaVersion = '7.1.1'
     return validate.schema
       .buildSchema({ version: remoteHedSchemaVersion })
       .then(hedSchema => {
@@ -124,6 +124,7 @@ describe('HED schemas', function() {
         pixels: 'px',
         speed: 'm-per-s',
         time: 's',
+        clockTime: 'hour:min',
         area: 'm^2',
         volume: 'm^3',
       }
@@ -139,7 +140,8 @@ describe('HED schemas', function() {
         physicalLength: ['metre', 'm', 'foot', 'mile'],
         pixels: ['pixel', 'px'],
         speed: ['m-per-s', 'mph', 'kph'],
-        time: ['second', 's', 'hour:min', 'day', 'minute', 'hour'],
+        time: ['second', 's', 'day', 'minute', 'hour'],
+        clockTime: ['hour:min', 'h:m', 'hour:min:sec', 'h:m:s'],
         area: ['m^2', 'px^2', 'pixel^2'],
         volume: ['m^3'],
       }

--- a/utils/__tests__/hed.spec.js
+++ b/utils/__tests__/hed.spec.js
@@ -62,7 +62,7 @@ describe('HED tag string utility functions', () => {
     })
   })
 
-  const localHedSchemaFile = 'tests/data/HED7.1.0.xml'
+  const localHedSchemaFile = 'tests/data/HED7.1.1.xml'
 
   describe('HED tag schema-based utility functions', () => {
     let hedSchemaPromise
@@ -260,7 +260,7 @@ describe('HED tag string utility functions', () => {
         'pixel',
       ]
       const currencyUnits = ['dollar', '$', 'point', 'fraction']
-      const timeUnits = ['second', 's', 'hour:min', 'day', 'minute', 'hour']
+      const timeUnits = ['second', 's', 'day', 'minute', 'hour']
       const expectedResults = {
         suffixed: directionUnits,
         prefixed: currencyUnits,

--- a/utils/__tests__/string.spec.js
+++ b/utils/__tests__/string.spec.js
@@ -66,30 +66,30 @@ describe('Character counts', function() {
 })
 
 describe('Valid HED times', function() {
-  it('must be of the form HH:MM', function() {
-    const validTime1 = '23:52'
-    const validTime2 = '00:55'
-    const validTime3 = '11:00'
-    const validTime4 = '8:24'
-    const invalidTime1 = '8/8/2019'
-    const invalidTime2 = '25:11'
-    const invalidTime3 = '12:65'
-    const invalidTime4 = 'not a time'
-    const validTime1Result = utils.string.isHourMinuteTime(validTime1)
-    const validTime2Result = utils.string.isHourMinuteTime(validTime2)
-    const validTime3Result = utils.string.isHourMinuteTime(validTime3)
-    const validTime4Result = utils.string.isHourMinuteTime(validTime4)
-    const invalidTime1Result = utils.string.isHourMinuteTime(invalidTime1)
-    const invalidTime2Result = utils.string.isHourMinuteTime(invalidTime2)
-    const invalidTime3Result = utils.string.isHourMinuteTime(invalidTime3)
-    const invalidTime4Result = utils.string.isHourMinuteTime(invalidTime4)
-    assert.strictEqual(validTime1Result, true)
-    assert.strictEqual(validTime2Result, true)
-    assert.strictEqual(validTime3Result, true)
-    assert.strictEqual(validTime4Result, true)
-    assert.strictEqual(invalidTime1Result, false)
-    assert.strictEqual(invalidTime2Result, false)
-    assert.strictEqual(invalidTime3Result, false)
-    assert.strictEqual(invalidTime4Result, false)
+  it('must be of the form HH:MM or HH:MM:SS', function() {
+    const validTestStrings = {
+      validPM: '23:52',
+      validMidnight: '00:55',
+      validHour: '11:00',
+      validSingleDigitHour: '8:24',
+      validSeconds: '19:33:47',
+    }
+    const invalidTestStrings = {
+      invalidDate: '8/8/2019',
+      invalidHour: '25:11',
+      invalidMinute: '12:65',
+      invalidSecond: '15:45:82',
+      invalidString: 'not a time',
+    }
+    for (const key in validTestStrings) {
+      const string = validTestStrings[key]
+      const result = utils.string.isClockFaceTime(string)
+      assert.strictEqual(result, true, string)
+    }
+    for (const key in invalidTestStrings) {
+      const string = invalidTestStrings[key]
+      const result = utils.string.isClockFaceTime(string)
+      assert.strictEqual(result, false, string)
+    }
   })
 })

--- a/utils/string.js
+++ b/utils/string.js
@@ -32,18 +32,18 @@ const capitalizeString = function(string) {
 }
 
 /**
- * Determine if a string is a valid hour-minute time.
+ * Determine if a string is a valid clock face time.
  *
  * @param timeString The string to check.
- * @return {boolean} Whether the string is a valid hour-minute time.
+ * @return {boolean} Whether the string is a valid clock face time.
  */
-const isHourMinuteTime = function(timeString) {
-  return date.isValid(timeString, 'H:mm')
+const isClockFaceTime = function(timeString) {
+  return date.isValid(timeString, 'H:mm') || date.isValid(timeString, 'H:mm:ss')
 }
 
 module.exports = {
   stringIsEmpty: stringIsEmpty,
   getCharacterCount: getCharacterCount,
   capitalizeString: capitalizeString,
-  isHourMinuteTime: isHourMinuteTime,
+  isClockFaceTime: isClockFaceTime,
 }

--- a/validators/hed.js
+++ b/validators/hed.js
@@ -572,8 +572,18 @@ const validateHedTagGroups = function(parsedString, issues) {
 /**
  * Validate the top-level HED tags in a parsed HED string.
  */
-const validateTopLevelTags = function(parsedString, hedSchema, issues) {
-  return checkForRequiredTags(parsedString, hedSchema, issues)
+const validateTopLevelTags = function(
+  parsedString,
+  hedSchema,
+  issues,
+  doSemanticValidation,
+  checkForWarnings,
+) {
+  if (doSemanticValidation && checkForWarnings) {
+    return checkForRequiredTags(parsedString, hedSchema, issues)
+  } else {
+    return true
+  }
 }
 
 /**
@@ -602,9 +612,15 @@ const validateHedString = function(
   }
 
   let valid = true
-  if (checkForWarnings) {
-    valid = valid && validateTopLevelTags(parsedString, hedSchema, issues)
-  }
+  valid =
+    valid &&
+    validateTopLevelTags(
+      parsedString,
+      hedSchema,
+      issues,
+      doSemanticValidation,
+      checkForWarnings,
+    )
   valid =
     valid &&
     validateIndividualHedTags(

--- a/validators/hed.js
+++ b/validators/hed.js
@@ -316,7 +316,7 @@ const checkIfTagUnitClassUnitsAreValid = function(
     )
     const valid =
       (tagUnitClasses.includes(timeUnitClass) &&
-        utils.string.isHourMinuteTime(formattedTagUnitValue)) ||
+        utils.string.isClockFaceTime(formattedTagUnitValue)) ||
       digitExpression.test(
         utils.HED.validateUnits(
           originalTagUnitValue,

--- a/validators/hed.js
+++ b/validators/hed.js
@@ -11,6 +11,8 @@ const delimiters = [comma, tilde]
 const uniqueType = 'unique'
 const requiredType = 'required'
 const requireChildType = 'requireChild'
+const unitsElement = 'units'
+const clockTimeUnitClass = 'clockTime'
 const timeUnitClass = 'time'
 
 const digitExpression = /^-?[\d.]+(?:[Ee]-?\d+)?$/
@@ -314,18 +316,30 @@ const checkIfTagUnitClassUnitsAreValid = function(
       formattedTag,
       hedSchema,
     )
-    const valid =
-      (tagUnitClasses.includes(timeUnitClass) &&
-        utils.string.isClockFaceTime(formattedTagUnitValue)) ||
-      digitExpression.test(
-        utils.HED.validateUnits(
-          originalTagUnitValue,
-          formattedTagUnitValue,
-          tagUnitClassUnits,
-          hedSchema,
-        ),
-      )
-    if (!valid) {
+    if (clockTimeUnitClass in hedSchema.dictionaries[unitsElement]) {
+      if (
+        tagUnitClasses.includes(clockTimeUnitClass) &&
+        utils.string.isClockFaceTime(formattedTagUnitValue)
+      ) {
+        return true
+      }
+    } else if (timeUnitClass in hedSchema.dictionaries[unitsElement]) {
+      if (
+        tagUnitClasses.includes(timeUnitClass) &&
+        utils.string.isClockFaceTime(formattedTagUnitValue)
+      ) {
+        return true
+      }
+    }
+    const validUnit = digitExpression.test(
+      utils.HED.validateUnits(
+        originalTagUnitValue,
+        formattedTagUnitValue,
+        tagUnitClassUnits,
+        hedSchema,
+      ),
+    )
+    if (!validUnit) {
       issues.push(
         utils.generateIssue('unitClassInvalidUnit', {
           tag: originalTag,
@@ -333,7 +347,7 @@ const checkIfTagUnitClassUnitsAreValid = function(
         }),
       )
     }
-    return valid
+    return validUnit
   } else {
     return true
   }


### PR DESCRIPTION
This implements the `clockTime` unit class. The code will now check if `clockTime` is a valid unit class and validates as a clock time if it exists and is a unit class of the tag in question. Then, if `clockTime` is not in the schema, it does the same thing with the `time` unit class. If `time` is not a valid unit class, no clock time validation is performed.

The test cases have been updated to v7.1.1 of the schema and all pass with the new code.