### PR TITLE
Split event- and string-level validation

### DIFF
--- a/tests/hed.spec.js
+++ b/tests/hed.spec.js
@@ -356,7 +356,7 @@ describe('Latest HED Schema', () => {
       const expectedResults = {
         takesValue: true,
         full: true,
-        extensionAllowed: true,
+        extensionAllowed: false,
         leafExtension: false,
         nonExtensionAllowed: false,
         illegalComma: false,
@@ -364,7 +364,9 @@ describe('Latest HED Schema', () => {
       const expectedIssues = {
         takesValue: [],
         full: [],
-        extensionAllowed: [],
+        extensionAllowed: [
+          generateIssue('extension', { tag: testStrings.extensionAllowed }),
+        ],
         leafExtension: [
           generateIssue('invalidTag', { tag: testStrings.leafExtension }),
         ],
@@ -382,7 +384,7 @@ describe('Latest HED Schema', () => {
         testStrings,
         expectedResults,
         expectedIssues,
-        false,
+        true,
       )
     })
 
@@ -440,9 +442,9 @@ describe('Latest HED Schema', () => {
       const testStrings = {
         hasRequiredUnit: 'Event/Duration/3 ms',
         missingRequiredUnit: 'Event/Duration/3',
-        notRequiredNoNumber: 'Attribute/Color/Red',
-        notRequiredNumber: 'Attribute/Color/Red/0.5',
-        notRequiredScientific: 'Attribute/Color/Red/5.2e-1',
+        notRequiredNoNumber: 'Attribute/Visual/Color/Red',
+        notRequiredNumber: 'Attribute/Visual/Color/Red/0.5',
+        notRequiredScientific: 'Attribute/Visual/Color/Red/5.2e-1',
         timeValue: 'Item/2D shape/Clock face/08:30',
       }
       const expectedResults = {
@@ -487,8 +489,8 @@ describe('Latest HED Schema', () => {
         incorrectPluralUnit: 'Attribute/Temporal rate/3 hertzs',
         incorrectSymbolCapitalizedUnit: 'Attribute/Temporal rate/3 hz',
         incorrectSymbolCapitalizedUnitModifier: 'Attribute/Temporal rate/3 KHz',
-        notRequiredNumber: 'Attribute/Color/Red/0.5',
-        notRequiredScientific: 'Attribute/Color/Red/5e-1',
+        notRequiredNumber: 'Attribute/Visual/Color/Red/0.5',
+        notRequiredScientific: 'Attribute/Visual/Color/Red/5e-1',
         properTime: 'Item/2D shape/Clock face/08:30',
         invalidTime: 'Item/2D shape/Clock face/54:54',
       }
@@ -830,8 +832,8 @@ describe('Pre-v7.1.0 HED Schemas', function() {
       const testStrings = {
         hasRequiredUnit: 'Event/Duration/3 ms',
         missingRequiredUnit: 'Event/Duration/3',
-        notRequiredNumber: 'Attribute/Color/Red/0.5',
-        notRequiredScientific: 'Attribute/Color/Red/5.2e-1',
+        notRequiredNumber: 'Attribute/Visual/Color/Red/0.5',
+        notRequiredScientific: 'Attribute/Visual/Color/Red/5.2e-1',
         timeValue: 'Item/2D shape/Clock face/08:30',
       }
       const expectedResults = {
@@ -869,8 +871,8 @@ describe('Pre-v7.1.0 HED Schemas', function() {
         incorrectUnit: 'Event/Duration/3 cm',
         incorrectUnitWord: 'Event/Duration/3 nanoseconds',
         incorrectPrefix: 'Event/Duration/3 ns',
-        notRequiredNumber: 'Attribute/Color/Red/0.5',
-        notRequiredScientific: 'Attribute/Color/Red/5e-1',
+        notRequiredNumber: 'Attribute/Visual/Color/Red/0.5',
+        notRequiredScientific: 'Attribute/Visual/Color/Red/5e-1',
         properTime: 'Item/2D shape/Clock face/08:30',
         invalidTime: 'Item/2D shape/Clock face/54:54',
       }

--- a/tests/hed.spec.js
+++ b/tests/hed.spec.js
@@ -70,7 +70,7 @@ describe('Latest HED Schema', () => {
   describe('Full HED Strings', () => {
     const validator = function(testStrings, expectedResults, expectedIssues) {
       for (const testStringKey in testStrings) {
-        const [testResult, testIssues] = hed.validateHedString(
+        const [testResult, testIssues] = hed.validateHedEvent(
           testStrings[testStringKey],
         )
         assert.strictEqual(
@@ -960,7 +960,7 @@ describe('Post-v8.0.0 HED Schemas', function() {
     const validator = function(testStrings, expectedResults, expectedIssues) {
       return hedSchemaPromise.then(hedSchema => {
         for (const testStringKey in testStrings) {
-          const [testResult, testIssues] = hed.validateHedString(
+          const [testResult, testIssues] = hed.validateHedEvent(
             testStrings[testStringKey],
             hedSchema,
             false,

--- a/tests/schema.spec.js
+++ b/tests/schema.spec.js
@@ -166,7 +166,7 @@ describe('HED schemas', function() {
         predicateType: 20,
         recommended: 0,
         requireChild: 64,
-        tags: 1116,
+        tags: 1116 - 119 + 2,
         takesValue: 119,
         unitClass: 63,
       }
@@ -201,7 +201,7 @@ describe('HED schemas', function() {
           recommended: false,
           required: false,
           requireChild: false,
-          tags: true,
+          tags: false,
           takesValue: true,
           unique: false,
           unitClass: true,

--- a/utils/__tests__/hed.spec.js
+++ b/utils/__tests__/hed.spec.js
@@ -115,7 +115,7 @@ describe('HED tag string utility functions', () => {
       const expectedResults = {
         direction: true,
         person: true,
-        validPound: true,
+        validPound: false,
         missingTopLevel: false,
         missingSub: false,
         missingValue: false,

--- a/utils/hed.js
+++ b/utils/hed.js
@@ -49,7 +49,7 @@ const getTagName = function(tag) {
 }
 
 /**
- * Get the last part of a HED tag.
+ * Get the HED tag prefix (up to the last slash).
  */
 const getParentTag = function(tag) {
   const lastSlashIndex = tag.lastIndexOf('/')

--- a/utils/hed.js
+++ b/utils/hed.js
@@ -49,6 +49,18 @@ const getTagName = function(tag) {
 }
 
 /**
+ * Get the last part of a HED tag.
+ */
+const getParentTag = function(tag) {
+  const lastSlashIndex = tag.lastIndexOf('/')
+  if (lastSlashIndex === -1) {
+    return tag
+  } else {
+    return tag.substring(0, lastSlashIndex)
+  }
+}
+
+/**
  * Get the list of valid derivatives of a unit.
  */
 const getValidUnitPlural = function(unit, hedSchemaAttributes) {
@@ -249,6 +261,7 @@ module.exports = {
   replaceTagNameWithPound: replaceTagNameWithPound,
   getTagSlashIndices: getTagSlashIndices,
   getTagName: getTagName,
+  getParentTag: getParentTag,
   stripOffUnitsIfValid: stripOffUnitsIfValid,
   validateUnits: validateUnits,
   tagExistsInSchema: tagExistsInSchema,

--- a/utils/hed.js
+++ b/utils/hed.js
@@ -149,6 +149,15 @@ const validateUnits = function(
   return formattedTagUnitValue
 }
 
+const digitExpression = /^-?[\d.]+(?:[Ee]-?\d+)?$/
+
+/**
+ * Determine if a stripped value is valid.
+ */
+const validateValue = function(value, allowPlaceholders) {
+  return digitExpression.test(value) || (allowPlaceholders && /^#$/.test(value))
+}
+
 /**
  * Determine if a HED tag is in the schema.
  */
@@ -264,6 +273,7 @@ module.exports = {
   getParentTag: getParentTag,
   stripOffUnitsIfValid: stripOffUnitsIfValid,
   validateUnits: validateUnits,
+  validateValue: validateValue,
   tagExistsInSchema: tagExistsInSchema,
   tagTakesValue: tagTakesValue,
   isUnitClassTag: isUnitClassTag,

--- a/utils/hed.js
+++ b/utils/hed.js
@@ -155,7 +155,7 @@ const digitExpression = /^-?[\d.]+(?:[Ee]-?\d+)?$/
  * Determine if a stripped value is valid.
  */
 const validateValue = function(value, allowPlaceholders) {
-  return digitExpression.test(value) || (allowPlaceholders && /^#$/.test(value))
+  return digitExpression.test(value) || (allowPlaceholders && value === '#')
 }
 
 /**

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -43,6 +43,9 @@ const generateIssue = function(code, parameters) {
     case 'invalidCharacter':
       issueObject.message = `ERROR: Invalid character "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
       break
+    case 'extension':
+      issueObject.message = `WARNING: Tag extension found - "${parameters.tag}"`
+      break
     default:
       issueObject.message = `ERROR: Unknown HED error.`
       break

--- a/validator/hed.js
+++ b/validator/hed.js
@@ -691,9 +691,9 @@ const initiallyValidateHedString = function(
 }
 
 /**
- * Validate a HED non-event string.
+ * Validate a HED string.
  *
- * @param {string} hedString The HED non-event string to validate.
+ * @param {string} hedString The HED string to validate.
  * @param {Schema} hedSchema The HED schema to validate against.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @param {boolean} allowPlaceholders Whether to treat value-taking tags with '#' placeholders as valid.

--- a/validator/hed.js
+++ b/validator/hed.js
@@ -28,7 +28,7 @@ const digitExpression = /^-?[\d.]+(?:[Ee]-?\d+)?$/
 const substituteCharacters = function(hedString) {
   const issues = []
   const illegalCharacterMap = { '\0': ['ASCII NUL', ' '] }
-  const flaggedCharacters = /[^\w\d./ -]/g
+  const flaggedCharacters = /[^\w\d./$ :-]/g
   const replaceFunction = function(match, offset) {
     if (match in illegalCharacterMap) {
       const [name, replacement] = illegalCharacterMap[match]

--- a/validator/schema.js
+++ b/validator/schema.js
@@ -235,10 +235,13 @@ const SchemaDictionaries = {
     return [tags, tagElements]
   },
 
-  getAllTags: function(tagElementName = 'node') {
+  getAllTags: function(tagElementName = 'node', excludeTakeValueTags = true) {
     const tags = []
     const tagElements = xpath.find(this.rootElement, '//' + tagElementName)
     for (const tagElement of tagElements) {
+      if (excludeTakeValueTags && this.getElementTagValue(tagElement) === '#') {
+        continue
+      }
       const tag = this.getTagPathFromTagElement(tagElement)
       tags.push(tag)
     }


### PR DESCRIPTION
This branch splits string-level validation from event-level validation. The new string-level validation skips tag group-level and top-level checks, including required and unique tag checks. It also handles `#` placeholders for values as an option, in order to support BIDS and other possible uses.

Extensions now are warned in all cases, and value tags are no longer included in the overall tag list.

Fixes #8