### PR TITLE
Treat all placeholders for non-takesValue tags as invalid

### DIFF
--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -860,12 +860,18 @@ describe('HED string and event validation', () => {
         const expectedIssues = {
           takesValue: [],
           withUnit: [],
-          child: [generateIssue('invalidTag', { tag: testStrings.child })],
+          child: [
+            generateIssue('invalidPlaceholder', { tag: testStrings.child }),
+          ],
           extensionAllowed: [
-            generateIssue('invalidTag', { tag: testStrings.extensionAllowed }),
+            generateIssue('invalidPlaceholder', {
+              tag: testStrings.extensionAllowed,
+            }),
           ],
           invalidParent: [
-            generateIssue('invalidTag', { tag: testStrings.invalidParent }),
+            generateIssue('invalidPlaceholder', {
+              tag: testStrings.invalidParent,
+            }),
           ],
           missingRequiredUnit: [
             generateIssue('unitClassDefaultUsed', {
@@ -874,7 +880,9 @@ describe('HED string and event validation', () => {
             }),
           ],
           wrongLocation: [
-            generateIssue('invalidTag', { tag: testStrings.wrongLocation }),
+            generateIssue('invalidPlaceholder', {
+              tag: testStrings.wrongLocation,
+            }),
           ],
         }
         return validator(testStrings, expectedResults, expectedIssues, true)

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -840,8 +840,9 @@ describe('HED string and event validation', () => {
 
       it('should properly handle strings with placeholders', () => {
         const testStrings = {
-          takesValue: 'Event/Duration/# ms',
-          full: 'Attribute/Object side/#',
+          takesValue: 'Attribute/Visual/Color/Red/#',
+          withUnit: 'Event/Duration/# ms',
+          child: 'Attribute/Object side/#',
           extensionAllowed: 'Item/Object/Person/Driver/#',
           invalidParent: 'Event/Nonsense/#',
           missingRequiredUnit: 'Event/Duration/#',
@@ -849,7 +850,8 @@ describe('HED string and event validation', () => {
         }
         const expectedResults = {
           takesValue: true,
-          full: true,
+          withUnit: true,
+          child: false,
           extensionAllowed: false,
           invalidParent: false,
           missingRequiredUnit: false,
@@ -857,9 +859,10 @@ describe('HED string and event validation', () => {
         }
         const expectedIssues = {
           takesValue: [],
-          full: [],
+          withUnit: [],
+          child: [generateIssue('invalidTag', { tag: testStrings.child })],
           extensionAllowed: [
-            generateIssue('extension', { tag: testStrings.extensionAllowed }),
+            generateIssue('invalidTag', { tag: testStrings.extensionAllowed }),
           ],
           invalidParent: [
             generateIssue('invalidTag', { tag: testStrings.invalidParent }),

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -46,6 +46,9 @@ const generateIssue = function(code, parameters) {
     case 'extension':
       issueObject.message = `WARNING: Tag extension found - "${parameters.tag}"`
       break
+    case 'invalidPlaceholder':
+      issueObject.message = `ERROR: Invalid placeholder - "${parameters.tag}"`
+      break
     default:
       issueObject.message = `ERROR: Unknown HED error.`
       break

--- a/validator/event.js
+++ b/validator/event.js
@@ -416,18 +416,9 @@ const checkIfTagIsValid = function(
     hedSchema.attributes,
   )
   if (allowPlaceholders && utils.HED.getTagName(formattedTag) === '#') {
-    const parentTag = utils.HED.getParentTag(formattedTag)
-    if (utils.HED.tagExistsInSchema(parentTag, hedSchema.attributes)) {
+    const valueTag = utils.HED.replaceTagNameWithPound(formattedTag)
+    if (utils.HED.tagTakesValue(valueTag, hedSchema.attributes)) {
       return []
-    } else if (
-      utils.HED.isExtensionAllowedTag(parentTag, hedSchema.attributes)
-    ) {
-      if (checkForWarnings) {
-        issues.push(utils.generateIssue('extension', { tag: originalTag }))
-        return issues
-      } else {
-        return []
-      }
     } else {
       issues.push(utils.generateIssue('invalidTag', { tag: originalTag }))
       return issues

--- a/validator/event.js
+++ b/validator/event.js
@@ -415,12 +415,14 @@ const checkIfTagIsValid = function(
     formattedTag,
     hedSchema.attributes,
   )
-  if (allowPlaceholders && utils.HED.getTagName(formattedTag) === '#') {
+  if (allowPlaceholders && formattedTag.split('#').length > 1) {
     const valueTag = utils.HED.replaceTagNameWithPound(formattedTag)
     if (utils.HED.tagTakesValue(valueTag, hedSchema.attributes)) {
       return []
     } else {
-      issues.push(utils.generateIssue('invalidTag', { tag: originalTag }))
+      issues.push(
+        utils.generateIssue('invalidPlaceholder', { tag: originalTag }),
+      )
       return issues
     }
   }


### PR DESCRIPTION
The previous version treated placeholders for child tags as valid. This PR fixes that issue.