### PR TITLE
Remove tilde support

### DIFF
--- a/converter/__tests__/converter.js
+++ b/converter/__tests__/converter.js
@@ -693,12 +693,6 @@ describe('HED string conversion', () => {
             '(Item/Object/Man-made/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5)',
           groupAndTag:
             '(Item/Object/Man-made/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5), Item/Object/Man-made/Vehicle/Car',
-          oneTildeGroup:
-            'Event/Sensory-event, (Item/Sound/Named-object-sound/Siren ~ Attribute/Environmental/Indoors)',
-          twoTildeGroup:
-            'Event/Sensory-event, (Attribute/Agent-related/Cognitive-state/Awake ~ Attribute/Agent-related/Trait/Age/15 ~' +
-            ' Item/Sound/Named-object-sound/Siren, Item/Object/Man-made/Vehicle/Car, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5),' +
-            ' Item/Object/Geometric',
         }
         const expectedResults = {
           singleLevel: 'Event',
@@ -708,9 +702,6 @@ describe('HED string conversion', () => {
           threeMulti: 'Sensory-event, Train, RGB-red/0.5',
           simpleGroup: '(Train, RGB-red/0.5)',
           groupAndTag: '(Train, RGB-red/0.5), Car',
-          oneTildeGroup: 'Sensory-event, (Siren ~ Indoors)',
-          twoTildeGroup:
-            'Sensory-event, (Awake ~ Age/15 ~ Siren, Car, RGB-red/0.5), Geometric',
         }
         const expectedIssues = {
           singleLevel: [],
@@ -720,8 +711,6 @@ describe('HED string conversion', () => {
           threeMulti: [],
           simpleGroup: [],
           groupAndTag: [],
-          oneTildeGroup: [],
-          twoTildeGroup: [],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })
@@ -920,9 +909,6 @@ describe('HED string conversion', () => {
           threeMulti: 'Sensory-event, Train, RGB-red/0.5',
           simpleGroup: '(Train, RGB-red/0.5)',
           groupAndTag: '(Train, RGB-red/0.5), Car',
-          oneTildeGroup: 'Sensory-event, (Siren ~ Indoors)',
-          twoTildeGroup:
-            'Sensory-event, (Awake ~ Age/15 ~ Siren, Car, RGB-red/0.5), Geometric',
         }
         const expectedResults = {
           singleLevel: 'Event',
@@ -935,12 +921,6 @@ describe('HED string conversion', () => {
             '(Item/Object/Man-made/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5)',
           groupAndTag:
             '(Item/Object/Man-made/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5), Item/Object/Man-made/Vehicle/Car',
-          oneTildeGroup:
-            'Event/Sensory-event, (Item/Sound/Named-object-sound/Siren ~ Attribute/Environmental/Indoors)',
-          twoTildeGroup:
-            'Event/Sensory-event, (Attribute/Agent-related/Cognitive-state/Awake ~ Attribute/Agent-related/Trait/Age/15 ~' +
-            ' Item/Sound/Named-object-sound/Siren, Item/Object/Man-made/Vehicle/Car, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5),' +
-            ' Item/Object/Geometric',
         }
         const expectedIssues = {
           singleLevel: [],
@@ -950,8 +930,6 @@ describe('HED string conversion', () => {
           threeMulti: [],
           simpleGroup: [],
           groupAndTag: [],
-          oneTildeGroup: [],
-          twoTildeGroup: [],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -60,10 +60,10 @@ describe('HED dataset validation', () => {
         multipleValidMixed: [],
         multipleInvalid: [
           generateValidationIssue('extension', {
-            tag: 'Item/Object/Man-made-object/Vehicle/Train/Maglev',
+            tag: testDatasets.multipleInvalid[0],
           }),
           generateValidationIssue('unitClassInvalidUnit', {
-            tag: 'Attribute/Spatiotemporal/Temporal/Duration/0.5 cm',
+            tag: testDatasets.multipleInvalid[1],
             unitClassUnits: legalTimeUnits.sort().join(','),
           }),
           generateConverterIssue(

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -1,7 +1,6 @@
 const assert = require('chai').assert
 const hed = require('../validator/event')
 const schema = require('../validator/schema')
-const converterSchema = require('../converter/schema')
 const stringParser = require('../validator/stringParser')
 const generateIssue = require('../utils/issues')
 const { Schemas } = require('../utils/schema')
@@ -103,16 +102,12 @@ describe('HED string and event validation', () => {
             ',/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
           extraClosingComma:
             '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px,',
-          extraOpeningTilde:
-            '~/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
-          extraClosingTilde:
-            '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px~',
           multipleExtraOpeningDelimiter:
-            ',~,/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
+            ',,/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
           multipleExtraClosingDelimiter:
-            '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px,~~,',
+            '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px,,',
           multipleExtraMiddleDelimiter:
-            '/Action/Reach/To touch,,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,~,/Attribute/Location/Screen/Left/23 px',
+            '/Action/Reach/To touch,,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,,/Attribute/Location/Screen/Left/23 px',
           valid:
             '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
           validDoubleOpeningParentheses:
@@ -143,20 +138,6 @@ describe('HED string and event validation', () => {
               string: testStrings.extraClosingComma,
             }),
           ],
-          extraOpeningTilde: [
-            generateIssue('extraDelimiter', {
-              character: '~',
-              index: 0,
-              string: testStrings.extraOpeningTilde,
-            }),
-          ],
-          extraClosingTilde: [
-            generateIssue('extraDelimiter', {
-              character: '~',
-              index: testStrings.extraClosingTilde.length - 1,
-              string: testStrings.extraClosingTilde,
-            }),
-          ],
           multipleExtraOpeningDelimiter: [
             generateIssue('extraDelimiter', {
               character: ',',
@@ -164,13 +145,8 @@ describe('HED string and event validation', () => {
               string: testStrings.multipleExtraOpeningDelimiter,
             }),
             generateIssue('extraDelimiter', {
-              character: '~',
-              index: 1,
-              string: testStrings.multipleExtraOpeningDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
               character: ',',
-              index: 2,
+              index: 1,
               string: testStrings.multipleExtraOpeningDelimiter,
             }),
           ],
@@ -181,18 +157,8 @@ describe('HED string and event validation', () => {
               string: testStrings.multipleExtraClosingDelimiter,
             }),
             generateIssue('extraDelimiter', {
-              character: '~',
-              index: testStrings.multipleExtraClosingDelimiter.length - 2,
-              string: testStrings.multipleExtraClosingDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
-              character: '~',
-              index: testStrings.multipleExtraClosingDelimiter.length - 3,
-              string: testStrings.multipleExtraClosingDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
               character: ',',
-              index: testStrings.multipleExtraClosingDelimiter.length - 4,
+              index: testStrings.multipleExtraClosingDelimiter.length - 2,
               string: testStrings.multipleExtraClosingDelimiter,
             }),
           ],
@@ -203,13 +169,8 @@ describe('HED string and event validation', () => {
               string: testStrings.multipleExtraMiddleDelimiter,
             }),
             generateIssue('extraDelimiter', {
-              character: '~',
-              index: 125,
-              string: testStrings.multipleExtraMiddleDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
               character: ',',
-              index: 126,
+              index: 125,
               string: testStrings.multipleExtraMiddleDelimiter,
             }),
           ],
@@ -230,6 +191,8 @@ describe('HED string and event validation', () => {
             '/Attribute/Object side/Left,/Participant/Effect[/Body part/Arm',
           closingBracket:
             '/Attribute/Object side/Left,/Participant/Effect]/Body part/Arm',
+          tilde:
+            '/Attribute/Object side/Left,/Participant/Effect~/Body part/Arm',
         }
         const expectedIssues = {
           openingBrace: [
@@ -258,6 +221,13 @@ describe('HED string and event validation', () => {
               character: ']',
               index: 47,
               string: testStrings.closingBracket,
+            }),
+          ],
+          tilde: [
+            generateIssue('invalidCharacter', {
+              character: '~',
+              index: 47,
+              string: testStrings.tilde,
             }),
           ],
         }
@@ -625,43 +595,6 @@ describe('HED string and event validation', () => {
           ],
         }
         return validator(testStrings, expectedIssues)
-      })
-    })
-
-    describe('HED Tag Groups', () => {
-      const validator = function (testStrings, expectedIssues) {
-        validatorSyntacticBase(
-          testStrings,
-          expectedIssues,
-          function (parsedTestString) {
-            return hed.validateHedTagGroups(parsedTestString)
-          },
-        )
-      }
-
-      it('should have no more than two tildes', () => {
-        const testStrings = {
-          noTildeGroup:
-            'Event/Category/Experimental stimulus,(Item/Object/Vehicle/Train,Event/Category/Experimental stimulus)',
-          oneTildeGroup:
-            'Event/Category/Experimental stimulus,(Item/Object/Vehicle/Car ~ Attribute/Object control/Perturb)',
-          twoTildeGroup:
-            'Event/Category/Experimental stimulus,(Participant/ID 1 ~ Participant/Effect/Visual ~ Item/Object/Vehicle/Car, Item/ID/RedCar, Attribute/Visual/Color/Red)',
-          invalidTildeGroup:
-            'Event/Category/Experimental stimulus,(Participant/ID 1 ~ Participant/Effect/Visual ~ Item/Object/Vehicle/Car, Item/ID/RedCar, Attribute/Visual/Color/Red ~ Attribute/Object control/Perturb)',
-        }
-        const expectedIssues = {
-          noTildeGroup: [],
-          oneTildeGroup: [],
-          twoTildeGroup: [],
-          invalidTildeGroup: [
-            generateIssue('tooManyTildes', {
-              tagGroup:
-                '(Participant/ID 1 ~ Participant/Effect/Visual ~ Item/Object/Vehicle/Car, Item/ID/RedCar, Attribute/Visual/Color/Red ~ Attribute/Object control/Perturb)',
-            }),
-          ],
-        }
-        validator(testStrings, expectedIssues)
       })
     })
 

--- a/validator/event.js
+++ b/validator/event.js
@@ -6,8 +6,7 @@ const { Schemas } = require('../utils/schema')
 const openingGroupCharacter = '('
 const closingGroupCharacter = ')'
 const comma = ','
-const tilde = '~'
-const delimiters = [comma, tilde]
+const delimiters = [comma]
 
 const uniqueType = 'unique'
 const requiredType = 'required'
@@ -186,7 +185,6 @@ const checkForDuplicateTags = function (tagList) {
         continue
       }
       if (
-        tagList[i].formattedTag !== tilde &&
         tagList[i].formattedTag === tagList[j].formattedTag &&
         !duplicateIndices.includes(i) &&
         !duplicateIndices.includes(j)
@@ -239,28 +237,6 @@ const checkForMultipleUniqueTags = function (tagList, hedSchemas) {
     }
   }
   return issues
-}
-
-/**
- * Verify that the tilde count in a single group does not exceed 2.
- */
-const checkNumberOfGroupTildes = function (originalTagGroup, parsedTagGroup) {
-  const issues = []
-  const tildeCount = utils.array.getElementCount(
-    parsedTagGroup.map((group) => {
-      return group.originalTag
-    }),
-    tilde,
-  )
-  if (tildeCount > 2) {
-    issues.push(
-      utils.generateIssue('tooManyTildes', {
-        tagGroup: originalTagGroup.originalTag,
-      }),
-    )
-    return issues
-  }
-  return []
 }
 
 /**
@@ -434,8 +410,7 @@ const checkIfTagIsValid = function (
     utils.HED.tagTakesValue(
       tag.formattedTag,
       hedSchemas.baseSchema.attributes,
-    ) || // This tag is a valid value-taking tag in the HED schema.
-    tag.formattedTag === tilde // This "tag" is a tilde.
+    ) // This tag is a valid value-taking tag in the HED schema.
   ) {
     return []
   }
@@ -670,7 +645,7 @@ const validateHedTagLevels = function (
  * Validate a HED tag group.
  */
 const validateHedTagGroup = function (originalTagGroup, parsedTagGroup) {
-  return checkNumberOfGroupTildes(originalTagGroup, parsedTagGroup)
+  return []
 }
 
 /**


### PR DESCRIPTION
This PR removes support for tilde validation, as brought up in https://github.com/hed-standard/hed-specification/issues/171. A couple of other lingering issues have also been fixed, including one regarding the passing of tag conversion issues through the string parser back to the main validation code.