### PR TITLE
Revamp issue handling

### DIFF
--- a/converter/__tests__/converter.js
+++ b/converter/__tests__/converter.js
@@ -267,14 +267,14 @@ describe('HED string conversion', () => {
             ),
           ],
           invalidSingle: [
-            generateIssue('noValidTagFound', testStrings.invalidSingle, {}, [
+            generateIssue('invalidTag', testStrings.invalidSingle, {}, [
               0,
               12,
             ]),
           ],
           invalidWithExtension: [
             generateIssue(
-              'noValidTagFound',
+              'invalidTag',
               testStrings.invalidWithExtension,
               {},
               [0, 12],
@@ -526,16 +526,16 @@ describe('HED string conversion', () => {
         }
         const expectedIssues = {
           single: [
-            generateIssue('noValidTagFound', testStrings.single, {}, [0, 12]),
+            generateIssue('invalidTag', testStrings.single, {}, [0, 12]),
           ],
           invalidChild: [
-            generateIssue('noValidTagFound', testStrings.invalidChild, {}, [
+            generateIssue('invalidTag', testStrings.invalidChild, {}, [
               0,
               12,
             ]),
           ],
           validChild: [
-            generateIssue('noValidTagFound', testStrings.validChild, {}, [
+            generateIssue('invalidTag', testStrings.validChild, {}, [
               0,
               12,
             ]),
@@ -575,7 +575,7 @@ describe('HED string conversion', () => {
         }
         const expectedIssues = {
           leadingSpace: [
-            generateIssue('noValidTagFound', testStrings.leadingSpace, {}, [
+            generateIssue('invalidTag', testStrings.leadingSpace, {}, [
               0,
               20,
             ]),
@@ -745,17 +745,17 @@ describe('HED string conversion', () => {
           doubleWithValid: double + ', Car/Minivan',
         }
         const expectedIssues = {
-          single: [generateIssue('noValidTagFound', single, {}, [0, 12])],
-          double: [generateIssue('noValidTagFound', double, {}, [0, 12])],
+          single: [generateIssue('invalidTag', single, {}, [0, 12])],
+          double: [generateIssue('invalidTag', double, {}, [0, 12])],
           both: [
-            generateIssue('noValidTagFound', single, {}, [0, 12]),
-            generateIssue('noValidTagFound', double, {}, [14, 26]),
+            generateIssue('invalidTag', single, {}, [0, 12]),
+            generateIssue('invalidTag', double, {}, [14, 26]),
           ],
           singleWithTwoValid: [
-            generateIssue('noValidTagFound', single, {}, [11, 23]),
+            generateIssue('invalidTag', single, {}, [11, 23]),
           ],
           doubleWithValid: [
-            generateIssue('noValidTagFound', double, {}, [0, 12]),
+            generateIssue('invalidTag', double, {}, [0, 12]),
           ],
         }
         return validator(testStrings, expectedResults, expectedIssues)
@@ -975,17 +975,17 @@ describe('HED string conversion', () => {
             double + ', Item/Object/Man-made/Vehicle/Car/Minivan',
         }
         const expectedIssues = {
-          single: [generateIssue('noValidTagFound', single, {}, [0, 12])],
-          double: [generateIssue('noValidTagFound', double, {}, [0, 12])],
+          single: [generateIssue('invalidTag', single, {}, [0, 12])],
+          double: [generateIssue('invalidTag', double, {}, [0, 12])],
           both: [
-            generateIssue('noValidTagFound', single, {}, [0, 12]),
-            generateIssue('noValidTagFound', double, {}, [14, 26]),
+            generateIssue('invalidTag', single, {}, [0, 12]),
+            generateIssue('invalidTag', double, {}, [14, 26]),
           ],
           singleWithTwoValid: [
-            generateIssue('noValidTagFound', single, {}, [11, 23]),
+            generateIssue('invalidTag', single, {}, [11, 23]),
           ],
           doubleWithValid: [
-            generateIssue('noValidTagFound', double, {}, [0, 12]),
+            generateIssue('invalidTag', double, {}, [0, 12]),
           ],
         }
         return validator(testStrings, expectedResults, expectedIssues)

--- a/converter/converter.js
+++ b/converter/converter.js
@@ -58,7 +58,7 @@ const convertTagToLong = function(mapping, hedTag, offset) {
           return [
             hedTag,
             [
-              generateIssue('noValidTagFound', hedTag, {}, [
+              generateIssue('invalidTag', hedTag, {}, [
                 startingIndex + offset,
                 endingIndex + offset,
               ]),
@@ -155,7 +155,7 @@ const convertTagToShort = function(mapping, hedTag, offset) {
     return [
       hedTag,
       [
-        generateIssue('noValidTagFound', hedTag, {}, [
+        generateIssue('invalidTag', hedTag, {}, [
           index + offset,
           lastFoundIndex + offset,
         ]),

--- a/converter/issues.js
+++ b/converter/issues.js
@@ -1,33 +1,23 @@
+const issuesUtil = require('../utils/issues')
+
 /**
  * Generate an issue object for tag conversion.
+ *
+ * This is simply a wrapper around the corresponding function in utils/issues.js
+ * that handles conversion-specific functionality.
  *
  * @param {string} code The issue code.
  * @param {string} hedString The source HED string.
  * @param {object} parameters The parameters to the format string.
  * @param {number[]} bounds The bounds of the problem tag.
- * @return {{code: string, sourceString: string, message: string}} The issue object.
+ * @return {Issue} The issue object.
  */
-const generateIssue = function(code, hedString, parameters = {}, bounds = []) {
-  const issueObject = { code: code, sourceString: hedString }
-  const problemTag = hedString.slice(bounds[0], bounds[1])
-  switch (code) {
-    case 'invalidParentNode':
-      issueObject.message = `ERROR: "${problemTag}" appears as "${parameters.parentTag}" and cannot be used as an extension. Indices (${bounds[0]}, ${bounds[1]}).`
-      break
-    case 'noValidTagFound':
-      issueObject.message = `ERROR: "${problemTag}" is not a valid base HED tag. Indices (${bounds[0]}, ${bounds[1]}).`
-      break
-    case 'emptyTagFound':
-      issueObject.message = `ERROR: Empty tag cannot be converted.`
-      break
-    case 'duplicateTagsInSchema':
-      issueObject.message = `ERROR: Source HED schema is invalid as it contains duplicate tags.`
-      break
-    default:
-      issueObject.message = `ERROR: Unknown HED error.`
-      break
-  }
-  return issueObject
+const generateIssue = function (code, hedString, parameters = {}, bounds = []) {
+  parameters.tag = hedString.slice(bounds[0], bounds[1])
+  parameters.bounds = bounds
+  const issue = issuesUtil.generateIssue(code, parameters)
+  issue.sourceString = hedString
+  return issue
 }
 
 module.exports = generateIssue

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -1,7 +1,7 @@
 const assert = require('chai').assert
 const hed = require('../validator/dataset')
 const schema = require('../validator/schema')
-const generateValidationIssue = require('../utils/issues')
+const generateValidationIssue = require('../utils/issues').generateIssue
 const generateConverterIssue = require('../converter/issues')
 
 describe('HED dataset validation', () => {
@@ -67,7 +67,7 @@ describe('HED dataset validation', () => {
             unitClassUnits: legalTimeUnits.sort().join(','),
           }),
           generateConverterIssue(
-            'noValidTagFound',
+            'invalidTag',
             testDatasets.multipleInvalid[2],
             {},
             [0, 12],

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -3,7 +3,7 @@ const hed = require('../validator/event')
 const schema = require('../validator/schema')
 const converterSchema = require('../converter/schema')
 const stringParser = require('../validator/stringParser')
-const generateIssue = require('../utils/issues')
+const generateIssue = require('../utils/issues').generateIssue
 
 describe('HED string and event validation', () => {
   describe('Latest HED schema', () => {

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -1,6 +1,6 @@
 const assert = require('chai').assert
 const stringParser = require('../validator/stringParser')
-const generateIssue = require('../utils/issues')
+const generateIssue = require('../utils/issues').generateIssue
 
 describe('HED string parsing', () => {
   const validatorWithoutIssues = function(

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,7 +4,7 @@ const HED = require('./hed')
 const array = require('./array')
 const files = require('./files')
 const string = require('./string')
-const generateIssue = require('./issues')
+const issues = require('./issues')
 
 // public api --------------------------------------------------------
 
@@ -12,8 +12,8 @@ const utils = {
   HED: HED,
   array: array,
   files: files,
+  issues: issues,
   string: string,
-  generateIssue: generateIssue,
 }
 
 // exports -----------------------------------------------------------

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -1,60 +1,99 @@
-const generateIssue = function(code, parameters) {
-  const issueObject = { code: code }
+/**
+ * A HED validation error or warning.
+ *
+ * @param {string} code The HED error code.
+ * @param {string} message The detailed error message.
+ * @constructor
+ */
+const Issue = function (code, message) {
+  /**
+   * The HED error code.
+   * @type {string}
+   */
+  this.code = code
+  /**
+   * The detailed error message.
+   * @type {string}
+   */
+  this.message = message
+}
+
+/**
+ * Generate a new issue object.
+ *
+ * @param {string} code The HED error code.
+ * @param {object} parameters The error string parameters.
+ * @return {Issue} An object representing the issue.
+ */
+const generateIssue = function (code, parameters) {
+  let message
   switch (code) {
     case 'parentheses':
-      issueObject.message = `ERROR: Number of opening and closing parentheses are unequal. ${parameters.opening} opening parentheses. ${parameters.closing} closing parentheses.`
+      message = `ERROR: Number of opening and closing parentheses are unequal. ${parameters.opening} opening parentheses. ${parameters.closing} closing parentheses.`
       break
     case 'invalidTag':
-      issueObject.message = `ERROR: Invalid tag - "${parameters.tag}"`
+      message = `ERROR: Invalid tag - "${parameters.tag}"`
       break
     case 'extraDelimiter':
-      issueObject.message = `ERROR: Extra delimiter "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
+      message = `ERROR: Extra delimiter "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
       break
     case 'commaMissing':
-      issueObject.message = `ERROR: Comma missing after - "${parameters.tag}"`
+      message = `ERROR: Comma missing after - "${parameters.tag}"`
       break
     case 'capitalization':
-      issueObject.message = `WARNING: First word not capitalized or camel case - "${parameters.tag}"`
+      message = `WARNING: First word not capitalized or camel case - "${parameters.tag}"`
       break
     case 'duplicateTag':
-      issueObject.message = `ERROR: Duplicate tag - "${parameters.tag}"`
+      message = `ERROR: Duplicate tag - "${parameters.tag}"`
       break
     case 'multipleUniqueTags':
-      issueObject.message = `ERROR: Multiple unique tags with prefix - "${parameters.tag}"`
+      message = `ERROR: Multiple unique tags with prefix - "${parameters.tag}"`
       break
     case 'tooManyTildes':
-      issueObject.message = `ERROR: Too many tildes - group "${parameters.tagGroup}"`
+      message = `ERROR: Too many tildes - group "${parameters.tagGroup}"`
       break
     case 'childRequired':
-      issueObject.message = `ERROR: Descendant tag required - "${parameters.tag}"`
+      message = `ERROR: Descendant tag required - "${parameters.tag}"`
       break
     case 'requiredPrefixMissing':
-      issueObject.message = `WARNING: Tag with prefix "${parameters.tagPrefix}" is required`
+      message = `WARNING: Tag with prefix "${parameters.tagPrefix}" is required`
       break
     case 'unitClassDefaultUsed':
-      issueObject.message = `WARNING: No unit specified. Using "${parameters.defaultUnit}" as the default - "${parameters.tag}"`
+      message = `WARNING: No unit specified. Using "${parameters.defaultUnit}" as the default - "${parameters.tag}"`
       break
     case 'unitClassInvalidUnit':
-      issueObject.message = `ERROR: Invalid unit - "${parameters.tag}" - valid units are "${parameters.unitClassUnits}"`
+      message = `ERROR: Invalid unit - "${parameters.tag}" - valid units are "${parameters.unitClassUnits}"`
       break
     case 'extraCommaOrInvalid':
-      issueObject.message = `ERROR: Either "${parameters.previousTag}" contains a comma when it should not or "${parameters.tag}" is not a valid tag`
+      message = `ERROR: Either "${parameters.previousTag}" contains a comma when it should not or "${parameters.tag}" is not a valid tag`
       break
     case 'invalidCharacter':
-      issueObject.message = `ERROR: Invalid character "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
+      message = `ERROR: Invalid character "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
       break
     case 'extension':
-      issueObject.message = `WARNING: Tag extension found - "${parameters.tag}"`
+      message = `WARNING: Tag extension found - "${parameters.tag}"`
       break
     case 'invalidPlaceholder':
-      issueObject.message = `ERROR: Invalid placeholder - "${parameters.tag}"`
+      message = `ERROR: Invalid placeholder - "${parameters.tag}"`
+      break
+    case 'invalidParentNode':
+      message = `ERROR: "${parameters.tag}" appears as "${parameters.parentTag}" and cannot be used as an extension. Indices (${parameters.bounds[0]}, ${parameters.bounds[1]}).`
+      break
+    case 'emptyTagFound':
+      message = `ERROR: Empty tag cannot be converted.`
+      break
+    case 'duplicateTagsInSchema':
+      message = `ERROR: Source HED schema is invalid as it contains duplicate tags.`
       break
     default:
-      issueObject.message = `ERROR: Unknown HED error.`
+      message = `ERROR: Unknown HED error.`
       break
   }
 
-  return issueObject
+  return new Issue(code, message)
 }
 
-module.exports = generateIssue
+module.exports = {
+  generateIssue: generateIssue,
+  Issue: Issue,
+}

--- a/validator/dataset.js
+++ b/validator/dataset.js
@@ -18,7 +18,7 @@ const parseDefinitions = function(hedStrings, hedSchema) {
  * @param {Definitions} definitions The parsed dataset definitions.
  * @param {string[]} hedStrings The dataset's HED strings.
  * @param {Schema} hedSchema The HED schema.
- * @return {[boolean, object[]]} Whether the HED dataset is valid and any issues found.
+ * @return {[boolean, Issue[]]} Whether the HED dataset is valid and any issues found.
  */
 const validateDataset = function(definitions, hedStrings, hedSchema) {
   // TODO: Implement
@@ -31,7 +31,7 @@ const validateDataset = function(definitions, hedStrings, hedSchema) {
  * @param {string[]} hedStrings A group of HED strings.
  * @param {Schema} hedSchema The HED schema.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
- * @return {Array} Whether the HED strings are valid and any issues found.
+ * @return {[boolean, Issue[]]} Whether the HED strings are valid and any issues found.
  */
 const validateHedEvents = function(hedStrings, hedSchema, checkForWarnings) {
   let stringsValid = true
@@ -54,7 +54,7 @@ const validateHedEvents = function(hedStrings, hedSchema, checkForWarnings) {
  * @param {string[]} hedStrings The dataset's HED strings.
  * @param {Schema} hedSchema The HED schema.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
- * @return {Array} Whether the HED dataset is valid and any issues found.
+ * @return {[boolean, Issue[]]} Whether the HED dataset is valid and any issues found.
  */
 const validateHedDataset = function(
   hedStrings,

--- a/validator/event.js
+++ b/validator/event.js
@@ -31,7 +31,7 @@ const substituteCharacters = function(hedString) {
     if (match in illegalCharacterMap) {
       const [name, replacement] = illegalCharacterMap[match]
       issues.push(
-        utils.generateIssue('invalidCharacter', {
+        utils.issues.generateIssue('invalidCharacter', {
           character: name,
           index: offset,
           string: hedString,
@@ -62,7 +62,7 @@ const countTagGroupParentheses = function(hedString) {
   )
   if (numberOfOpeningParentheses !== numberOfClosingParentheses) {
     issues.push(
-      utils.generateIssue('parentheses', {
+      utils.issues.generateIssue('parentheses', {
         opening: numberOfOpeningParentheses,
         closing: numberOfClosingParentheses,
       }),
@@ -104,7 +104,7 @@ const findDelimiterIssuesInHedString = function(hedString) {
     if (delimiters.includes(currentCharacter)) {
       if (currentTag.trim() === currentCharacter) {
         issues.push(
-          utils.generateIssue('extraDelimiter', {
+          utils.issues.generateIssue('extraDelimiter', {
             character: currentCharacter,
             index: i,
             string: hedString,
@@ -118,7 +118,7 @@ const findDelimiterIssuesInHedString = function(hedString) {
       if (currentTag.trim() === openingGroupCharacter) {
         currentTag = ''
       } else {
-        issues.push(utils.generateIssue('invalidTag', { tag: currentTag }))
+        issues.push(utils.issues.generateIssue('invalidTag', { tag: currentTag }))
       }
     } else if (
       isCommaMissingAfterClosingParenthesis(
@@ -127,7 +127,7 @@ const findDelimiterIssuesInHedString = function(hedString) {
       )
     ) {
       issues.push(
-        utils.generateIssue('commaMissing', {
+        utils.issues.generateIssue('commaMissing', {
           tag: currentTag.slice(0, -1),
         }),
       )
@@ -138,7 +138,7 @@ const findDelimiterIssuesInHedString = function(hedString) {
   }
   if (delimiters.includes(lastNonEmptyValidCharacter)) {
     issues.push(
-      utils.generateIssue('extraDelimiter', {
+      utils.issues.generateIssue('extraDelimiter', {
         character: lastNonEmptyValidCharacter,
         index: lastNonEmptyValidIndex,
         string: hedString,
@@ -170,7 +170,7 @@ const checkCapitalization = function(
   for (const tagName of tagNames) {
     const correctTagName = utils.string.capitalizeString(tagName)
     if (tagName !== correctTagName && !camelCase.test(tagName)) {
-      issues.push(utils.generateIssue('capitalization', { tag: originalTag }))
+      issues.push(utils.issues.generateIssue('capitalization', { tag: originalTag }))
     }
   }
   return issues
@@ -197,7 +197,7 @@ const checkForDuplicateTags = function(originalTagList, formattedTagList) {
       ) {
         duplicateIndices.push(i, j)
         issues.push(
-          utils.generateIssue('duplicateTag', { tag: originalTagList[i] }),
+          utils.issues.generateIssue('duplicateTag', { tag: originalTagList[i] }),
         )
       }
     }
@@ -223,7 +223,7 @@ const checkForMultipleUniqueTags = function(
           foundOne = true
         } else {
           issues.push(
-            utils.generateIssue('multipleUniqueTags', {
+            utils.issues.generateIssue('multipleUniqueTags', {
               tag: uniqueTagPrefix,
             }),
           )
@@ -243,7 +243,7 @@ const checkNumberOfGroupTildes = function(originalTagGroup, parsedTagGroup) {
   const tildeCount = utils.array.getElementCount(parsedTagGroup, tilde)
   if (tildeCount > 2) {
     issues.push(
-      utils.generateIssue('tooManyTildes', { tagGroup: originalTagGroup }),
+      utils.issues.generateIssue('tooManyTildes', { tagGroup: originalTagGroup }),
     )
     return issues
   }
@@ -258,7 +258,7 @@ const checkIfTagRequiresChild = function(originalTag, formattedTag, hedSchema) {
   const invalid =
     formattedTag in hedSchema.attributes.dictionaries[requireChildType]
   if (invalid) {
-    issues.push(utils.generateIssue('childRequired', { tag: originalTag }))
+    issues.push(utils.issues.generateIssue('childRequired', { tag: originalTag }))
   }
   return issues
 }
@@ -280,7 +280,7 @@ const checkForRequiredTags = function(parsedString, hedSchema) {
     }
     if (!foundOne) {
       issues.push(
-        utils.generateIssue('requiredPrefixMissing', {
+        utils.issues.generateIssue('requiredPrefixMissing', {
           tagPrefix: requiredTagPrefix,
         }),
       )
@@ -308,7 +308,7 @@ const checkIfTagUnitClassUnitsExist = function(
         hedSchema.attributes,
       )
       issues.push(
-        utils.generateIssue('unitClassDefaultUsed', {
+        utils.issues.generateIssue('unitClassDefaultUsed', {
           tag: originalTag,
           defaultUnit: defaultUnit,
         }),
@@ -378,7 +378,7 @@ const checkIfTagUnitClassUnitsAreValid = function(
     const validUnit = utils.HED.validateValue(value, allowPlaceholders)
     if (!validUnit) {
       issues.push(
-        utils.generateIssue('unitClassInvalidUnit', {
+        utils.issues.generateIssue('unitClassInvalidUnit', {
           tag: originalTag,
           unitClassUnits: tagUnitClassUnits.sort().join(','),
         }),
@@ -421,7 +421,7 @@ const checkIfTagIsValid = function(
       return []
     } else {
       issues.push(
-        utils.generateIssue('invalidPlaceholder', { tag: originalTag }),
+        utils.issues.generateIssue('invalidPlaceholder', { tag: originalTag }),
       )
       return issues
     }
@@ -433,7 +433,7 @@ const checkIfTagIsValid = function(
     // This tag isn't an allowed extension, but the previous tag takes a value.
     // This is likely caused by an extraneous comma.
     issues.push(
-      utils.generateIssue('extraCommaOrInvalid', {
+      utils.issues.generateIssue('extraCommaOrInvalid', {
         tag: originalTag,
         previousTag: previousOriginalTag,
       }),
@@ -441,12 +441,12 @@ const checkIfTagIsValid = function(
     return issues
   } else if (!isExtensionAllowedTag) {
     // This is not a valid tag.
-    issues.push(utils.generateIssue('invalidTag', { tag: originalTag }))
+    issues.push(utils.issues.generateIssue('invalidTag', { tag: originalTag }))
     return issues
   } else {
     // This is an allowed extension.
     if (checkForWarnings) {
-      issues.push(utils.generateIssue('extension', { tag: originalTag }))
+      issues.push(utils.issues.generateIssue('extension', { tag: originalTag }))
       return issues
     } else {
       return []
@@ -693,7 +693,7 @@ const initiallyValidateHedString = function(
  * @param {Schema} hedSchema The HED schema to validate against.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @param {boolean} allowPlaceholders Whether to treat value-taking tags with '#' placeholders as valid.
- * @returns {Array} Whether the HED string is valid and any issues found.
+ * @returns {[boolean, Issue[]]} Whether the HED string is valid and any issues found.
  */
 const validateHedString = function(
   hedString,
@@ -734,7 +734,7 @@ const validateHedString = function(
  * @param {string} hedString The HED event string to validate.
  * @param {Schema} hedSchema The HED schema to validate against.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
- * @returns {Array} Whether the HED string is valid and any issues found.
+ * @returns {[boolean, Issue[]]} Whether the HED string is valid and any issues found.
  */
 const validateHedEvent = function(
   hedString,

--- a/validator/stringParser.js
+++ b/validator/stringParser.js
@@ -65,7 +65,7 @@ const splitHedString = function(hedString, issues) {
     } else if (invalidCharacters.includes(character)) {
       // Found an invalid character, so push an issue.
       issues.push(
-        utils.generateIssue('invalidCharacter', {
+        utils.issues.generateIssue('invalidCharacter', {
           character: character,
           index: i,
           string: hedString,


### PR DESCRIPTION
This commit merges the two issue generating modules into `utils/issues.js`, creates a new Issue type for issues, and changes the export list for `utils/issues.js` to also export the new type. The `converter/issues.js` module was kept as a wrapper to deal with conversion-specific functionality. The `noValidTagFound` error code was deleted as redundant and merged into `invalidTag`. All other issue codes were left unmodified pending the finalization of the HED 3 error code specification. All instances of issue generation in validation and test code were updated, and all tests pass. The Issue object is backwards-compatible, as the fields have the same names as before, so no major version bump is needed.