### PR TITLE
Use Mapping for HED 2 strings and various other fixes

### DIFF
--- a/converter/__tests__/converter.js
+++ b/converter/__tests__/converter.js
@@ -18,7 +18,7 @@ describe('HED string conversion', () => {
      * @param {Object<string, string>} testStrings The test strings.
      * @param {Object<string, string>} expectedResults The expected results.
      * @param {Object<string, Issue[]>} expectedIssues The expected issues.
-     * @param {function (Mapping, string, number): [string, Issue[]]} testFunction The test function.
+     * @param {function (Schemas, string, string, number): [string, Issue[]]} testFunction The test function.
      * @return {Promise<void> | PromiseLike<any> | Promise<any>}
      */
     const validatorBase = function (
@@ -30,7 +30,8 @@ describe('HED string conversion', () => {
       return schemaPromise.then((schemas) => {
         for (const testStringKey in testStrings) {
           const [testResult, issues] = testFunction(
-            schemas.baseSchema.mapping,
+            schemas,
+            testStrings[testStringKey],
             testStrings[testStringKey],
             0,
           )
@@ -608,7 +609,8 @@ describe('HED string conversion', () => {
           bothSingle: 'Event',
           bothExtension: 'Event/Extension',
           bothMultiLevel: 'Item/Object/Man-made-object/Vehicle/Train',
-          bothMultiLevelExtension: 'Item/Object/Man-made-object/Vehicle/Train/Maglev',
+          bothMultiLevelExtension:
+            'Item/Object/Man-made-object/Vehicle/Train/Maglev',
         }
         const expectedIssues = {
           leadingSingle: [],
@@ -735,13 +737,21 @@ describe('HED string conversion', () => {
           single: [generateIssue('invalidTag', single, {}, [0, 12])],
           double: [generateIssue('invalidTag', double, {}, [0, 12])],
           both: [
-            generateIssue('invalidTag', single, {}, [0, 12]),
-            generateIssue('invalidTag', double, {}, [14, 26]),
+            generateIssue('invalidTag', testStrings.both, {}, [0, 12]),
+            generateIssue('invalidTag', testStrings.both, {}, [14, 26]),
           ],
           singleWithTwoValid: [
-            generateIssue('invalidTag', single, {}, [11, 23]),
+            generateIssue('invalidTag', testStrings.singleWithTwoValid, {}, [
+              11,
+              23,
+            ]),
           ],
-          doubleWithValid: [generateIssue('invalidTag', double, {}, [0, 12])],
+          doubleWithValid: [
+            generateIssue('invalidTag', testStrings.doubleWithValid, {}, [
+              0,
+              12,
+            ]),
+          ],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })
@@ -956,13 +966,21 @@ describe('HED string conversion', () => {
           single: [generateIssue('invalidTag', single, {}, [0, 12])],
           double: [generateIssue('invalidTag', double, {}, [0, 12])],
           both: [
-            generateIssue('invalidTag', single, {}, [0, 12]),
-            generateIssue('invalidTag', double, {}, [14, 26]),
+            generateIssue('invalidTag', testStrings.both, {}, [0, 12]),
+            generateIssue('invalidTag', testStrings.both, {}, [14, 26]),
           ],
           singleWithTwoValid: [
-            generateIssue('invalidTag', single, {}, [11, 23]),
+            generateIssue('invalidTag', testStrings.singleWithTwoValid, {}, [
+              11,
+              23,
+            ]),
           ],
-          doubleWithValid: [generateIssue('invalidTag', double, {}, [0, 12])],
+          doubleWithValid: [
+            generateIssue('invalidTag', testStrings.doubleWithValid, {}, [
+              0,
+              12,
+            ]),
+          ],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })

--- a/converter/schema.js
+++ b/converter/schema.js
@@ -15,7 +15,7 @@ const Mapping = types.Mapping
  * @param {object} xmlData The schema XML data.
  * @return {Mapping} The mapping object.
  */
-const buildMappingObject = function(xmlData) {
+const buildMappingObject = function (xmlData) {
   const nodeData = {}
   let hasNoDuplicates = true
   const rootElement = xmlData.HED
@@ -44,7 +44,7 @@ const buildMappingObject = function(xmlData) {
   return new Mapping(nodeData, hasNoDuplicates)
 }
 
-const getTagPathFromTagElement = function(tagElement) {
+const getTagPathFromTagElement = function (tagElement) {
   const ancestorTags = [getElementTagValue(tagElement)]
   let parentTagName = getParentTagName(tagElement)
   let parentElement = tagElement.$parent
@@ -56,11 +56,11 @@ const getTagPathFromTagElement = function(tagElement) {
   return ancestorTags
 }
 
-const getElementTagValue = function(element, tagName = 'name') {
+const getElementTagValue = function (element, tagName = 'name') {
   return element[tagName][0]._
 }
 
-const getParentTagName = function(tagElement) {
+const getParentTagName = function (tagElement) {
   const parentTagElement = tagElement.$parent
   if (parentTagElement && 'name' in parentTagElement) {
     return parentTagElement.name[0]._
@@ -75,8 +75,8 @@ const getParentTagName = function(tagElement) {
  * @param {{path: string?, version: string?}} schemaDef The description of which schema to use.
  * @return {Promise<never>|Promise<Schemas>} The schema container object or an error.
  */
-const buildSchema = function(schemaDef = {}) {
-  return schemaUtils.loadSchema(schemaDef).then(xmlData => {
+const buildSchema = function (schemaDef = {}) {
+  return schemaUtils.loadSchema(schemaDef).then((xmlData) => {
     const mapping = buildMappingObject(xmlData)
     const baseSchema = new schemaUtils.Schema(xmlData, undefined, mapping)
     return new schemaUtils.Schemas(baseSchema)

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -76,9 +76,24 @@ describe('HED string parsing', () => {
         tilde: '/Attribute/Object side/Left,/Participant/Effect~/Body part/Arm',
       }
       const expectedResultList = [
-        new ParsedHedTag('/Attribute/Object side/Left', [0, 27], nullSchema),
-        new ParsedHedTag('/Participant/Effect', [28, 47], nullSchema),
-        new ParsedHedTag('/Body part/Arm', [48, 62], nullSchema),
+        new ParsedHedTag(
+          '/Attribute/Object side/Left',
+          '/Attribute/Object side/Left',
+          [0, 27],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Participant/Effect',
+          '/Participant/Effect',
+          [28, 47],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Body part/Arm',
+          '/Body part/Arm',
+          [48, 62],
+          nullSchema,
+        ),
       ]
       const expectedResults = {
         openingCurly: expectedResultList,
@@ -182,11 +197,22 @@ describe('HED string parsing', () => {
       assert.deepStrictEqual(result, [
         new ParsedHedTag(
           'Event/Category/Experimental stimulus',
+          'Event/Category/Experimental stimulus',
           [0, 36],
           nullSchema,
         ),
-        new ParsedHedTag('Item/Object/Vehicle/Train', [37, 62], nullSchema),
-        new ParsedHedTag('Attribute/Visual/Color/Purple', [63, 92], nullSchema),
+        new ParsedHedTag(
+          'Item/Object/Vehicle/Train',
+          'Item/Object/Vehicle/Train',
+          [37, 62],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          'Attribute/Visual/Color/Purple',
+          'Attribute/Visual/Color/Purple',
+          [63, 92],
+          nullSchema,
+        ),
       ])
     })
 
@@ -196,18 +222,26 @@ describe('HED string parsing', () => {
       const [result, issues] = splitHedString(hedString, nullSchema)
       assert.deepStrictEqual(issues, [])
       assert.deepStrictEqual(result, [
-        new ParsedHedTag('/Action/Reach/To touch', [0, 22], nullSchema),
         new ParsedHedTag(
+          '/Action/Reach/To touch',
+          '/Action/Reach/To touch',
+          [0, 22],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
           '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
           [23, 86],
           nullSchema,
         ),
         new ParsedHedTag(
           '/Attribute/Location/Screen/Top/70 px',
+          '/Attribute/Location/Screen/Top/70 px',
           [87, 123],
           nullSchema,
         ),
         new ParsedHedTag(
+          '/Attribute/Location/Screen/Left/23 px',
           '/Attribute/Location/Screen/Left/23 px',
           [124, 161],
           nullSchema,
@@ -252,8 +286,14 @@ describe('HED string parsing', () => {
           '/Item/Object/Vehicle/Car, /Attribute/Object control/Perturb,',
       }
       const expectedList = [
-        new ParsedHedTag('/Item/Object/Vehicle/Car', [0, 24], nullSchema),
         new ParsedHedTag(
+          '/Item/Object/Vehicle/Car',
+          '/Item/Object/Vehicle/Car',
+          [0, 24],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Attribute/Object control/Perturb',
           '/Attribute/Object control/Perturb',
           [26, 59],
           nullSchema,
@@ -327,7 +367,7 @@ describe('HED string parsing', () => {
         openingAndClosingDoubleQuotedSlash: formattedHedTag,
       }
       validatorWithoutIssues(testStrings, expectedResults, (string) => {
-        const parsedTag = new ParsedHedTag(string, [], nullSchema)
+        const parsedTag = new ParsedHedTag(string, string, [], nullSchema)
         formatHedTag(parsedTag)
         return parsedTag.formattedTag
       })

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -9,7 +9,7 @@ const files = require('../utils/files')
  * @param {{path: string?, library: string?, version: string?}} schemaDef The description of which schema to use.
  * @return {Promise<never>|Promise<object>} The schema XML data or an error.
  */
-const loadSchema = function(schemaDef = {}) {
+const loadSchema = function (schemaDef = {}) {
   if (Object.entries(schemaDef).length === 0) {
     return loadRemoteSchema()
   } else if (schemaDef.path) {
@@ -30,7 +30,7 @@ const loadSchema = function(schemaDef = {}) {
  * @param {string?} library The library schema to load.
  * @return {Promise<object>} The schema XML data.
  */
-const loadRemoteSchema = function(version = 'Latest', library) {
+const loadRemoteSchema = function (version = 'Latest', library) {
   let fileName
   let basePath
   if (library) {
@@ -45,10 +45,10 @@ const loadRemoteSchema = function(version = 'Latest', library) {
   const url = basePath + fileName
   return files
     .readHTTPSFile(url)
-    .then(data => {
+    .then((data) => {
       return xml2js.parseStringPromise(data, { explicitCharkey: true })
     })
-    .catch(error => {
+    .catch((error) => {
       throw new Error(
         'Could not load HED schema version "' +
           version +
@@ -65,13 +65,13 @@ const loadRemoteSchema = function(version = 'Latest', library) {
  * @param {string} path The path to the schema XML data.
  * @return {Promise<object>} The schema XML data.
  */
-const loadLocalSchema = function(path) {
+const loadLocalSchema = function (path) {
   return files
     .readFile(path)
-    .then(data => {
+    .then((data) => {
       return xml2js.parseStringPromise(data, { explicitCharkey: true })
     })
-    .catch(error => {
+    .catch((error) => {
       throw new Error(
         'Could not load HED schema from path "' + path + '" - "' + error + '".',
       )
@@ -84,7 +84,7 @@ const loadLocalSchema = function(path) {
  * @param {object} node The child node.
  * @param {object} parent The parent node.
  */
-const setParent = function(node, parent) {
+const setParent = function (node, parent) {
   // Assume that we've already run this function if so.
   if ('$parent' in node) {
     return

--- a/validator/event.js
+++ b/validator/event.js
@@ -427,7 +427,10 @@ const checkIfTagIsValid = function (
   )
   if (allowPlaceholders && tag.formattedTag.split('#').length === 2) {
     const valueTag = utils.HED.replaceTagNameWithPound(tag.formattedTag)
-    if (utils.HED.tagTakesValue(valueTag, hedSchemas.baseSchema.attributes)) {
+    if (
+      valueTag.split('#').length !== 2 || // To avoid a redundant issue.
+      utils.HED.tagTakesValue(valueTag, hedSchemas.baseSchema.attributes)
+    ) {
       return []
     } else {
       issues.push(
@@ -470,6 +473,36 @@ const checkIfTagIsValid = function (
     } else {
       return []
     }
+  }
+}
+
+/**
+ * Check basic placeholder syntax.
+ *
+ * @param {ParsedHedTag} tag A HED tag.
+ * @return {Issue[]} Any issues found.
+ */
+const checkPlaceholderSyntax = function (tag) {
+  if (tag.formattedTag.split('#').length < 2) {
+    return []
+  } else if (tag.formattedTag.split('#').length === 2) {
+    const valueTag = utils.HED.replaceTagNameWithPound(tag.formattedTag)
+    if (valueTag.split('#').length !== 2) {
+      return [
+        utils.issues.generateIssue('invalidPlaceholder', {
+          tag: tag.originalTag,
+        }),
+      ]
+    } else {
+      return []
+    }
+  } else {
+    // More than two placeholders.
+    return [
+      utils.issues.generateIssue('invalidPlaceholder', {
+        tag: tag.originalTag,
+      }),
+    ]
   }
 }
 
@@ -639,6 +672,9 @@ const validateIndividualHedTag = function (
       checkCapitalization(tag, hedSchemas, doSemanticValidation),
     )
   }
+  if (allowPlaceholders) {
+    issues = issues.concat(checkPlaceholderSyntax(tag))
+  }
   return issues
 }
 
@@ -653,7 +689,7 @@ const validateIndividualHedTags = function (
   allowPlaceholders = false,
 ) {
   let issues = []
-  let previousTag = new ParsedHedTag('', [0, 0], hedSchemas)
+  let previousTag = new ParsedHedTag('', '', [0, 0], hedSchemas)
   for (let i = 0; i < parsedString.tags.length; i++) {
     const tag = parsedString.tags[i]
     issues = issues.concat(
@@ -784,15 +820,25 @@ const initiallyValidateHedString = function (
       hedString.hedString,
     )
     if (fullHedStringIssues.length !== 0) {
-      return [false, fullHedStringIssues.concat(substitutionIssues), null]
+      return [
+        false,
+        false,
+        fullHedStringIssues.concat(substitutionIssues),
+        null,
+      ]
     }
-    return [true, substitutionIssues, hedString]
+    return [true, true, substitutionIssues, hedString]
   } else {
     const [substitutionIssues, fullHedStringIssues] = validateFullHedString(
       hedString,
     )
     if (fullHedStringIssues.length !== 0) {
-      return [false, fullHedStringIssues.concat(substitutionIssues), null]
+      return [
+        false,
+        false,
+        fullHedStringIssues.concat(substitutionIssues),
+        null,
+      ]
     }
 
     const [parsedString, parsedStringIssues] = parseHedString(
@@ -800,10 +846,15 @@ const initiallyValidateHedString = function (
       hedSchemas,
     )
     if (parsedStringIssues.length !== 0) {
-      return [false, parsedStringIssues.concat(substitutionIssues), null]
+      return [
+        true,
+        false,
+        parsedStringIssues.concat(substitutionIssues),
+        parsedString,
+      ]
     }
 
-    return [true, substitutionIssues, parsedString]
+    return [true, true, substitutionIssues, parsedString]
   }
 }
 
@@ -822,14 +873,21 @@ const validateHedString = function (
   checkForWarnings = false,
   allowPlaceholders = false,
 ) {
-  const doSemanticValidation = hedSchemas instanceof Schemas
+  let doSemanticValidation = hedSchemas instanceof Schemas
+  if (!doSemanticValidation) {
+    hedSchemas = new Schemas(null)
+  }
   const [
-    initiallyValid,
+    fullStringValid,
+    parsedStringValid,
     initialIssues,
     parsedString,
   ] = initiallyValidateHedString(hedString, hedSchemas, doSemanticValidation)
-  if (!initiallyValid) {
+  if (!fullStringValid) {
     return [false, initialIssues]
+  } else if (!parsedStringValid) {
+    doSemanticValidation = false
+    hedSchemas = new Schemas(null)
   }
 
   const issues = initialIssues.concat(
@@ -867,11 +925,12 @@ const validateHedEvent = function (
     hedSchemas = new Schemas(null)
   }
   const [
-    initiallyValid,
+    fullStringValid,
+    parsedStringValid,
     initialIssues,
     parsedString,
   ] = initiallyValidateHedString(hedString, hedSchemas, doSemanticValidation)
-  if (!initiallyValid) {
+  if (!(fullStringValid && parsedStringValid)) {
     return [false, initialIssues]
   }
 

--- a/validator/schema.js
+++ b/validator/schema.js
@@ -1,5 +1,3 @@
-const semver = require('semver')
-
 // TODO: Switch require once upstream bugs are fixed.
 // const xpath = require('xml2js-xpath')
 // Temporary
@@ -39,7 +37,7 @@ const unitsElement = 'units'
 const unitModifierElement = 'unitModifier'
 
 const SchemaDictionaries = {
-  populateDictionaries: function() {
+  populateDictionaries: function () {
     this.dictionaries = {}
     this.populateUnitClassDictionaries()
     this.populateUnitModifierDictionaries()
@@ -47,17 +45,17 @@ const SchemaDictionaries = {
     return this.dictionaries
   },
 
-  populateTagDictionaries: function() {
+  populateTagDictionaries: function () {
     for (const dictionaryKey of tagDictionaryKeys) {
       const [tags, tagElements] = this.getTagsByAttribute(dictionaryKey)
       if (dictionaryKey === extensionAllowedAttribute) {
         const tagDictionary = this.stringListToLowercaseDictionary(tags)
         const childTagElements = arrayUtils.flattenDeep(
-          tagElements.map(tagElement => {
+          tagElements.map((tagElement) => {
             return this.getAllChildTags(tagElement)
           }),
         )
-        const childTags = childTagElements.map(tagElement => {
+        const childTags = childTagElements.map((tagElement) => {
           return this.getTagPathFromTagElement(tagElement)
         })
         const childDictionary = this.stringListToLowercaseDictionary(childTags)
@@ -84,7 +82,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateUnitClassDictionaries: function() {
+  populateUnitClassDictionaries: function () {
     const unitClassElements = this.getElementsByName(unitClassElement)
     if (unitClassElements.length === 0) {
       this.hasUnitClasses = false
@@ -95,7 +93,7 @@ const SchemaDictionaries = {
     this.populateUnitClassDefaultUnitDictionary(unitClassElements)
   },
 
-  populateUnitClassUnitsDictionary: function(unitClassElements) {
+  populateUnitClassUnitsDictionary: function (unitClassElements) {
     this.dictionaries[unitsElement] = {}
     for (const unitClassKey of unitClassDictionaryKeys) {
       this.dictionaries[unitClassKey] = {}
@@ -110,12 +108,12 @@ const SchemaDictionaries = {
           unitClassUnitsElement,
         )
         const units = elementUnits.split(',')
-        this.dictionaries[unitsElement][unitClassName] = units.map(unit => {
+        this.dictionaries[unitsElement][unitClassName] = units.map((unit) => {
           return unit.toLowerCase()
         })
         continue
       }
-      const unitNames = units.map(element => {
+      const unitNames = units.map((element) => {
         return element._
       })
       this.dictionaries[unitsElement][unitClassName] = unitNames
@@ -130,7 +128,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateUnitClassDefaultUnitDictionary: function(unitClassElements) {
+  populateUnitClassDefaultUnitDictionary: function (unitClassElements) {
     this.dictionaries[defaultUnitForUnitClassAttribute] = {}
     for (const unitClassElement of unitClassElements) {
       const elementName = this.getElementTagValue(unitClassElement)
@@ -146,7 +144,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateUnitModifierDictionaries: function() {
+  populateUnitModifierDictionaries: function () {
     const unitModifierElements = this.getElementsByName(unitModifierElement)
     if (unitModifierElements.length === 0) {
       this.hasUnitModifiers = false
@@ -169,7 +167,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateTagToAttributeDictionary: function(
+  populateTagToAttributeDictionary: function (
     tagList,
     tagElementList,
     attributeName,
@@ -182,7 +180,7 @@ const SchemaDictionaries = {
     }
   },
 
-  stringListToLowercaseDictionary: function(stringList) {
+  stringListToLowercaseDictionary: function (stringList) {
     const lowercaseDictionary = {}
     for (const stringElement of stringList) {
       lowercaseDictionary[stringElement.toLowerCase()] = stringElement
@@ -190,7 +188,7 @@ const SchemaDictionaries = {
     return lowercaseDictionary
   },
 
-  getAncestorTagNames: function(tagElement) {
+  getAncestorTagNames: function (tagElement) {
     const ancestorTags = []
     let parentTagName = this.getParentTagName(tagElement)
     let parentElement = tagElement.$parent
@@ -202,11 +200,11 @@ const SchemaDictionaries = {
     return ancestorTags
   },
 
-  getElementTagValue: function(element, tagName = 'name') {
+  getElementTagValue: function (element, tagName = 'name') {
     return element[tagName][0]._
   },
 
-  getParentTagName: function(tagElement) {
+  getParentTagName: function (tagElement) {
     const parentTagElement = tagElement.$parent
     if (parentTagElement && parentTagElement !== this.rootElement) {
       return parentTagElement.name[0]._
@@ -215,14 +213,14 @@ const SchemaDictionaries = {
     }
   },
 
-  getTagPathFromTagElement: function(tagElement) {
+  getTagPathFromTagElement: function (tagElement) {
     const ancestorTagNames = this.getAncestorTagNames(tagElement)
     ancestorTagNames.unshift(this.getElementTagValue(tagElement))
     ancestorTagNames.reverse()
     return ancestorTagNames.join('/')
   },
 
-  getTagsByAttribute: function(attributeName) {
+  getTagsByAttribute: function (attributeName) {
     const tags = []
     const tagElements = xpath.find(
       this.rootElement,
@@ -235,7 +233,7 @@ const SchemaDictionaries = {
     return [tags, tagElements]
   },
 
-  getAllTags: function(tagElementName = 'node', excludeTakeValueTags = true) {
+  getAllTags: function (tagElementName = 'node', excludeTakeValueTags = true) {
     const tags = []
     const tagElements = xpath.find(this.rootElement, '//' + tagElementName)
     for (const tagElement of tagElements) {
@@ -248,7 +246,10 @@ const SchemaDictionaries = {
     return [tags, tagElements]
   },
 
-  getElementsByName: function(elementName = 'node', parentElement = undefined) {
+  getElementsByName: function (
+    elementName = 'node',
+    parentElement = undefined,
+  ) {
     if (!parentElement) {
       return xpath.find(this.rootElement, '//' + elementName)
     } else {
@@ -256,7 +257,7 @@ const SchemaDictionaries = {
     }
   },
 
-  getAllChildTags: function(
+  getAllChildTags: function (
     parentElement,
     elementName = 'node',
     excludeTakeValueTags = true,
@@ -272,7 +273,7 @@ const SchemaDictionaries = {
       parentElement,
     )
     const childTags = arrayUtils.flattenDeep(
-      tagElementChildren.map(child => {
+      tagElementChildren.map((child) => {
         return this.getAllChildTags(child, elementName, excludeTakeValueTags)
       }),
     )
@@ -288,7 +289,7 @@ const SchemaDictionaries = {
  * @param {string} tagAttribute The attribute to check for.
  * @return {boolean} Whether this tag has this attribute.
  */
-const tagHasAttribute = function(tag, tagAttribute) {
+const tagHasAttribute = function (tag, tagAttribute) {
   return tag.toLowerCase() in this.dictionaries[tagAttribute]
 }
 
@@ -300,7 +301,7 @@ const tagHasAttribute = function(tag, tagAttribute) {
  * @param {boolean} hasUnitModifiers Whether the schema has unit modifiers.
  * @constructor
  */
-const SchemaAttributes = function(
+const SchemaAttributes = function (
   dictionaries,
   hasUnitClasses,
   hasUnitModifiers,
@@ -317,7 +318,7 @@ const SchemaAttributes = function(
  * @param {object} xmlData The schema XML data.
  * @return {SchemaAttributes} The schema attributes object.
  */
-const buildSchemaAttributesObject = function(xmlData) {
+const buildSchemaAttributesObject = function (xmlData) {
   const schemaDictionaries = Object.create(SchemaDictionaries)
   const rootElement = xmlData.HED
   schemaUtils.setParent(rootElement, xmlData)
@@ -336,13 +337,10 @@ const buildSchemaAttributesObject = function(xmlData) {
  * @param {{path: string?, version: string?}} schemaDef The description of which base schema to use.
  * @return {Promise<never>|Promise<Schemas>} The schema container object or an error.
  */
-const buildSchema = function(schemaDef = {}) {
-  return schemaUtils.loadSchema(schemaDef).then(xmlData => {
+const buildSchema = function (schemaDef = {}) {
+  return schemaUtils.loadSchema(schemaDef).then((xmlData) => {
     const schemaAttributes = buildSchemaAttributesObject(xmlData)
-    let mapping
-    if (semver.gte(xmlData.HED.$.version, '8.0.0-alpha')) {
-      mapping = buildMappingObject(xmlData)
-    }
+    const mapping = buildMappingObject(xmlData)
     const baseSchema = new schemaUtils.Schema(
       xmlData,
       schemaAttributes,


### PR DESCRIPTION
This PR passes HED 2 strings through a modified short-to-long conversion as part of the string parsing process. It also adds a new syntax-only placeholder validation check (`#` counts only), and string-level syntax checks now always run even if string parsing has errors. The tests have been adjusted and should pass, and other minor fixes have been made.

Fixes #18