### PR TITLE
Myriad of HED 3-related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dataset-validation, hed-3 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dataset-validation, hed-3 ]
 
 jobs:
   Build:

--- a/converter/__tests__/converter.js
+++ b/converter/__tests__/converter.js
@@ -27,10 +27,10 @@ describe('HED string conversion', () => {
       expectedIssues,
       testFunction,
     ) {
-      return schemaPromise.then((schema) => {
+      return schemaPromise.then((schemas) => {
         for (const testStringKey in testStrings) {
           const [testResult, issues] = testFunction(
-            schema.mapping,
+            schemas.baseSchema.mapping,
             testStrings[testStringKey],
             0,
           )
@@ -636,7 +636,7 @@ describe('HED string conversion', () => {
      * @param {Object<string, string>} testStrings The test strings.
      * @param {Object<string, string>} expectedResults The expected results.
      * @param {Object<string, Issue[]>} expectedIssues The expected issues.
-     * @param {function (Schema, string): [string, Issue[]]} testFunction The test function.
+     * @param {function (Schemas, string): [string, Issue[]]} testFunction The test function.
      * @return {Promise<void> | PromiseLike<any> | Promise<any>}
      */
     const validatorBase = function (
@@ -645,10 +645,10 @@ describe('HED string conversion', () => {
       expectedIssues,
       testFunction,
     ) {
-      return schemaPromise.then((schema) => {
+      return schemaPromise.then((schemas) => {
         for (const testStringKey in testStrings) {
           const [testResult, issues] = testFunction(
-            schema,
+            schemas,
             testStrings[testStringKey],
           )
           assert.strictEqual(

--- a/converter/__tests__/converter.js
+++ b/converter/__tests__/converter.js
@@ -691,12 +691,6 @@ describe('HED string conversion', () => {
             '(Item/Object/Man-made-object/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5)',
           groupAndTag:
             '(Item/Object/Man-made-object/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5), Item/Object/Man-made-object/Vehicle/Car',
-          oneTildeGroup:
-            'Event/Sensory-event, (Item/Sound/Named-object-sound/Siren ~ Attribute/Environmental/Indoors)',
-          twoTildeGroup:
-            'Event/Sensory-event, (Agent-property/Cognitive-state/Awake ~ Agent-property/Agent-trait/Age/15 ~' +
-            ' Item/Sound/Named-object-sound/Siren, Item/Object/Man-made-object/Vehicle/Car, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5),' +
-            ' Item/Object/Geometric',
         }
         const expectedResults = {
           singleLevel: 'Event',
@@ -706,9 +700,6 @@ describe('HED string conversion', () => {
           threeMulti: 'Sensory-event, Train, RGB-red/0.5',
           simpleGroup: '(Train, RGB-red/0.5)',
           groupAndTag: '(Train, RGB-red/0.5), Car',
-          oneTildeGroup: 'Sensory-event, (Siren ~ Indoors)',
-          twoTildeGroup:
-            'Sensory-event, (Awake ~ Age/15 ~ Siren, Car, RGB-red/0.5), Geometric',
         }
         const expectedIssues = {
           singleLevel: [],
@@ -718,8 +709,6 @@ describe('HED string conversion', () => {
           threeMulti: [],
           simpleGroup: [],
           groupAndTag: [],
-          oneTildeGroup: [],
-          twoTildeGroup: [],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })
@@ -920,9 +909,6 @@ describe('HED string conversion', () => {
           threeMulti: 'Sensory-event, Train, RGB-red/0.5',
           simpleGroup: '(Train, RGB-red/0.5)',
           groupAndTag: '(Train, RGB-red/0.5), Car',
-          oneTildeGroup: 'Sensory-event, (Siren ~ Indoors)',
-          twoTildeGroup:
-            'Sensory-event, (Awake ~ Age/15 ~ Siren, Car, RGB-red/0.5), Geometric',
         }
         const expectedResults = {
           singleLevel: 'Event',
@@ -935,12 +921,6 @@ describe('HED string conversion', () => {
             '(Item/Object/Man-made-object/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5)',
           groupAndTag:
             '(Item/Object/Man-made-object/Vehicle/Train, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5), Item/Object/Man-made-object/Vehicle/Car',
-          oneTildeGroup:
-            'Event/Sensory-event, (Item/Sound/Named-object-sound/Siren ~ Attribute/Environmental/Indoors)',
-          twoTildeGroup:
-            'Event/Sensory-event, (Agent-property/Cognitive-state/Awake ~ Agent-property/Agent-trait/Age/15 ~' +
-            ' Item/Sound/Named-object-sound/Siren, Item/Object/Man-made-object/Vehicle/Car, Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5),' +
-            ' Item/Object/Geometric',
         }
         const expectedIssues = {
           singleLevel: [],
@@ -950,8 +930,6 @@ describe('HED string conversion', () => {
           threeMulti: [],
           simpleGroup: [],
           groupAndTag: [],
-          oneTildeGroup: [],
-          twoTildeGroup: [],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })

--- a/converter/__tests__/converter.js
+++ b/converter/__tests__/converter.js
@@ -18,7 +18,7 @@ describe('HED string conversion', () => {
      * @param {Object<string, string>} testStrings The test strings.
      * @param {Object<string, string>} expectedResults The expected results.
      * @param {Object<string, Issue[]>} expectedIssues The expected issues.
-     * @param {function (Mapping, string, number): [string, Issue[]]} testFunction The test function.
+     * @param {function (Schemas, string, string, number): [string, Issue[]]} testFunction The test function.
      * @return {Promise<void> | PromiseLike<any> | Promise<any>}
      */
     const validatorBase = function (
@@ -30,7 +30,8 @@ describe('HED string conversion', () => {
       return schemaPromise.then((schemas) => {
         for (const testStringKey in testStrings) {
           const [testResult, issues] = testFunction(
-            schemas.baseSchema.mapping,
+            schemas,
+            testStrings[testStringKey],
             testStrings[testStringKey],
             0,
           )
@@ -608,7 +609,8 @@ describe('HED string conversion', () => {
           bothSingle: 'Event',
           bothExtension: 'Event/Extension',
           bothMultiLevel: 'Item/Object/Man-made-object/Vehicle/Train',
-          bothMultiLevelExtension: 'Item/Object/Man-made-object/Vehicle/Train/Maglev',
+          bothMultiLevelExtension:
+            'Item/Object/Man-made-object/Vehicle/Train/Maglev',
         }
         const expectedIssues = {
           leadingSingle: [],
@@ -735,13 +737,21 @@ describe('HED string conversion', () => {
           single: [generateIssue('invalidTag', single, {}, [0, 12])],
           double: [generateIssue('invalidTag', double, {}, [0, 12])],
           both: [
-            generateIssue('invalidTag', single, {}, [0, 12]),
-            generateIssue('invalidTag', double, {}, [14, 26]),
+            generateIssue('invalidTag', testStrings.both, {}, [0, 12]),
+            generateIssue('invalidTag', testStrings.both, {}, [14, 26]),
           ],
           singleWithTwoValid: [
-            generateIssue('invalidTag', single, {}, [11, 23]),
+            generateIssue('invalidTag', testStrings.singleWithTwoValid, {}, [
+              11,
+              23,
+            ]),
           ],
-          doubleWithValid: [generateIssue('invalidTag', double, {}, [0, 12])],
+          doubleWithValid: [
+            generateIssue('invalidTag', testStrings.doubleWithValid, {}, [
+              0,
+              12,
+            ]),
+          ],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })
@@ -956,13 +966,21 @@ describe('HED string conversion', () => {
           single: [generateIssue('invalidTag', single, {}, [0, 12])],
           double: [generateIssue('invalidTag', double, {}, [0, 12])],
           both: [
-            generateIssue('invalidTag', single, {}, [0, 12]),
-            generateIssue('invalidTag', double, {}, [14, 26]),
+            generateIssue('invalidTag', testStrings.both, {}, [0, 12]),
+            generateIssue('invalidTag', testStrings.both, {}, [14, 26]),
           ],
           singleWithTwoValid: [
-            generateIssue('invalidTag', single, {}, [11, 23]),
+            generateIssue('invalidTag', testStrings.singleWithTwoValid, {}, [
+              11,
+              23,
+            ]),
           ],
-          doubleWithValid: [generateIssue('invalidTag', double, {}, [0, 12])],
+          doubleWithValid: [
+            generateIssue('invalidTag', testStrings.doubleWithValid, {}, [
+              0,
+              12,
+            ]),
+          ],
         }
         return validator(testStrings, expectedResults, expectedIssues)
       })

--- a/converter/converter.js
+++ b/converter/converter.js
@@ -187,14 +187,14 @@ const convertTagToShort = function(mapping, hedTag, offset) {
 /**
  * Convert a HED string.
  *
- * @param {Schema} schema The schema object containing a short-to-long mapping.
+ * @param {Schemas} schemas The schema container object containing short-to-long mappings.
  * @param {string} hedString The HED tag to convert.
  * @param {function (Mapping, string, number): [string, []]} conversionFn The conversion function for a tag.
  * @return {[string, []]} The converted string and any issues.
  */
-const convertHedString = function(schema, hedString, conversionFn) {
+const convertHedString = function(schemas, hedString, conversionFn) {
   let issues = []
-  const mapping = schema.mapping
+  const mapping = schemas.baseSchema.mapping
 
   if (!mapping.hasNoDuplicates) {
     issues.push(generateIssue('duplicateTagsInSchema', ''))
@@ -232,23 +232,23 @@ const convertHedString = function(schema, hedString, conversionFn) {
 /**
  * Convert a HED string to long form.
  *
- * @param {Schema} schema The schema object containing a short-to-long mapping.
+ * @param {Schemas} schemas The schema container object containing short-to-long mappings.
  * @param {string} hedString The HED tag to convert.
  * @return {[string, []]} The long-form string and any issues.
  */
-const convertHedStringToLong = function(schema, hedString) {
-  return convertHedString(schema, hedString, convertTagToLong)
+const convertHedStringToLong = function(schemas, hedString) {
+  return convertHedString(schemas, hedString, convertTagToLong)
 }
 
 /**
  * Convert a HED string to short form.
  *
- * @param {Schema} schema The schema object containing a short-to-long mapping.
+ * @param {Schemas} schemas The schema container object containing short-to-long mappings.
  * @param {string} hedString The HED tag to convert.
  * @return {[string, []]} The short-form string and any issues.
  */
-const convertHedStringToShort = function(schema, hedString) {
-  return convertHedString(schema, hedString, convertTagToShort)
+const convertHedStringToShort = function(schemas, hedString) {
+  return convertHedString(schemas, hedString, convertTagToShort)
 }
 
 module.exports = {

--- a/converter/schema.js
+++ b/converter/schema.js
@@ -15,7 +15,7 @@ const Mapping = types.Mapping
  * @param {object} xmlData The schema XML data.
  * @return {Mapping} The mapping object.
  */
-const buildMappingObject = function(xmlData) {
+const buildMappingObject = function (xmlData) {
   const nodeData = {}
   let hasNoDuplicates = true
   const rootElement = xmlData.HED
@@ -44,7 +44,7 @@ const buildMappingObject = function(xmlData) {
   return new Mapping(nodeData, hasNoDuplicates)
 }
 
-const getTagPathFromTagElement = function(tagElement) {
+const getTagPathFromTagElement = function (tagElement) {
   const ancestorTags = [getElementTagValue(tagElement)]
   let parentTagName = getParentTagName(tagElement)
   let parentElement = tagElement.$parent
@@ -56,11 +56,11 @@ const getTagPathFromTagElement = function(tagElement) {
   return ancestorTags
 }
 
-const getElementTagValue = function(element, tagName = 'name') {
+const getElementTagValue = function (element, tagName = 'name') {
   return element[tagName][0]._
 }
 
-const getParentTagName = function(tagElement) {
+const getParentTagName = function (tagElement) {
   const parentTagElement = tagElement.$parent
   if (parentTagElement && 'name' in parentTagElement) {
     return parentTagElement.name[0]._
@@ -75,8 +75,8 @@ const getParentTagName = function(tagElement) {
  * @param {{path: string?, version: string?}} schemaDef The description of which schema to use.
  * @return {Promise<never>|Promise<Schemas>} The schema container object or an error.
  */
-const buildSchema = function(schemaDef = {}) {
-  return schemaUtils.loadSchema(schemaDef).then(xmlData => {
+const buildSchema = function (schemaDef = {}) {
+  return schemaUtils.loadSchema(schemaDef).then((xmlData) => {
     const mapping = buildMappingObject(xmlData)
     const baseSchema = new schemaUtils.Schema(xmlData, undefined, mapping)
     return new schemaUtils.Schemas(baseSchema)

--- a/converter/schema.js
+++ b/converter/schema.js
@@ -70,15 +70,16 @@ const getParentTagName = function(tagElement) {
 }
 
 /**
- * Build a schema object containing a short-long mapping from a schema version or path description.
+ * Build a schema container object containing a short-long mapping from a base schema version or path description.
  *
  * @param {{path: string?, version: string?}} schemaDef The description of which schema to use.
- * @return {Promise<never>|Promise<Schema>} The schema object or an error.
+ * @return {Promise<never>|Promise<Schemas>} The schema container object or an error.
  */
 const buildSchema = function(schemaDef = {}) {
   return schemaUtils.loadSchema(schemaDef).then(xmlData => {
     const mapping = buildMappingObject(xmlData)
-    return new schemaUtils.Schema(xmlData, undefined, mapping)
+    const baseSchema = new schemaUtils.Schema(xmlData, undefined, mapping)
+    return new schemaUtils.Schemas(baseSchema)
   })
 }
 

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -60,10 +60,10 @@ describe('HED dataset validation', () => {
         multipleValidMixed: [],
         multipleInvalid: [
           generateValidationIssue('extension', {
-            tag: 'Item/Object/Man-made-object/Vehicle/Train/Maglev',
+            tag: testDatasets.multipleInvalid[0],
           }),
           generateValidationIssue('unitClassInvalidUnit', {
-            tag: 'Data-property/Spatiotemporal/Temporal/Duration/0.5 cm',
+            tag: testDatasets.multipleInvalid[1],
             unitClassUnits: legalTimeUnits.sort().join(','),
           }),
           generateConverterIssue(

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -1081,5 +1081,65 @@ describe('HED string and event validation', () => {
         return validatorSemantic(testStrings, expectedIssues, true)
       })
     })
+
+    describe('HED Tag Levels', () => {
+      const validatorSyntactic = function (testStrings, expectedIssues) {
+        validatorSyntacticBase(
+          testStrings,
+          expectedIssues,
+          function (parsedTestString) {
+            return hed.validateHedTagLevels(parsedTestString, {}, false)
+          },
+        )
+      }
+
+      const validatorSemantic = function (testStrings, expectedIssues) {
+        return validatorSemanticBase(
+          testStrings,
+          expectedIssues,
+          function (parsedTestString, schema) {
+            return hed.validateHedTagLevels(parsedTestString, schema, true)
+          },
+        )
+      }
+
+      it('should have syntactically valid definitions', () => {
+        const testStrings = {
+          nonDefinition: 'Car',
+          nonDefinitionGroup: '(Train/Maglev,Age/15,RGB-red/0.5)',
+          definitionOnly: '(Definition/SimpleDefinition)',
+          tagGroup: '(Definition/TagGroupDefinition, (Square, RGB-blue))',
+          illegalSibling:
+            '(Definition/IllegalSiblingDefinition, Train, (Visual))',
+          nestedDefinition:
+            '(Definition/NestedDefinition, (Screen, (Definition/InnerDefinition, (Square))))',
+          multipleTagGroups:
+            '(Definition/MultipleTagGroupDefinition, (Screen), (Square))',
+        }
+        const expectedIssues = {
+          nonDefinition: [],
+          nonDefinitionGroup: [],
+          definitionOnly: [],
+          tagGroup: [],
+          illegalSibling: [
+            generateIssue('illegalDefinitionGroupTag', {
+              tag: 'Train',
+              definition: 'IllegalSiblingDefinition',
+            }),
+          ],
+          nestedDefinition: [
+            generateIssue('nestedDefinition', {
+              definition: 'NestedDefinition',
+            }),
+          ],
+          multipleTagGroups: [
+            generateIssue('multipleTagGroupsInDefinition', {
+              definition: 'MultipleTagGroupDefinition',
+            }),
+          ],
+        }
+        return validatorSemantic(testStrings, expectedIssues)
+      })
+    })
   })
 })

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -102,16 +102,12 @@ describe('HED string and event validation', () => {
             ',/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
           extraClosingComma:
             '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px,',
-          extraOpeningTilde:
-            '~/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
-          extraClosingTilde:
-            '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px~',
           multipleExtraOpeningDelimiter:
-            ',~,/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
+            ',,/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
           multipleExtraClosingDelimiter:
-            '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px,~~,',
+            '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px,,',
           multipleExtraMiddleDelimiter:
-            '/Action/Reach/To touch,,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,~,/Attribute/Location/Screen/Left/23 px',
+            '/Action/Reach/To touch,,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,,/Attribute/Location/Screen/Left/23 px',
           valid:
             '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px',
           validDoubleOpeningParentheses:
@@ -142,20 +138,6 @@ describe('HED string and event validation', () => {
               string: testStrings.extraClosingComma,
             }),
           ],
-          extraOpeningTilde: [
-            generateIssue('extraDelimiter', {
-              character: '~',
-              index: 0,
-              string: testStrings.extraOpeningTilde,
-            }),
-          ],
-          extraClosingTilde: [
-            generateIssue('extraDelimiter', {
-              character: '~',
-              index: testStrings.extraClosingTilde.length - 1,
-              string: testStrings.extraClosingTilde,
-            }),
-          ],
           multipleExtraOpeningDelimiter: [
             generateIssue('extraDelimiter', {
               character: ',',
@@ -163,13 +145,8 @@ describe('HED string and event validation', () => {
               string: testStrings.multipleExtraOpeningDelimiter,
             }),
             generateIssue('extraDelimiter', {
-              character: '~',
-              index: 1,
-              string: testStrings.multipleExtraOpeningDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
               character: ',',
-              index: 2,
+              index: 1,
               string: testStrings.multipleExtraOpeningDelimiter,
             }),
           ],
@@ -180,18 +157,8 @@ describe('HED string and event validation', () => {
               string: testStrings.multipleExtraClosingDelimiter,
             }),
             generateIssue('extraDelimiter', {
-              character: '~',
-              index: testStrings.multipleExtraClosingDelimiter.length - 2,
-              string: testStrings.multipleExtraClosingDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
-              character: '~',
-              index: testStrings.multipleExtraClosingDelimiter.length - 3,
-              string: testStrings.multipleExtraClosingDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
               character: ',',
-              index: testStrings.multipleExtraClosingDelimiter.length - 4,
+              index: testStrings.multipleExtraClosingDelimiter.length - 2,
               string: testStrings.multipleExtraClosingDelimiter,
             }),
           ],
@@ -202,13 +169,8 @@ describe('HED string and event validation', () => {
               string: testStrings.multipleExtraMiddleDelimiter,
             }),
             generateIssue('extraDelimiter', {
-              character: '~',
-              index: 125,
-              string: testStrings.multipleExtraMiddleDelimiter,
-            }),
-            generateIssue('extraDelimiter', {
               character: ',',
-              index: 126,
+              index: 125,
               string: testStrings.multipleExtraMiddleDelimiter,
             }),
           ],
@@ -229,6 +191,8 @@ describe('HED string and event validation', () => {
             '/Attribute/Object side/Left,/Participant/Effect[/Body part/Arm',
           closingBracket:
             '/Attribute/Object side/Left,/Participant/Effect]/Body part/Arm',
+          tilde:
+            '/Attribute/Object side/Left,/Participant/Effect~/Body part/Arm',
         }
         const expectedIssues = {
           openingBrace: [
@@ -257,6 +221,13 @@ describe('HED string and event validation', () => {
               character: ']',
               index: 47,
               string: testStrings.closingBracket,
+            }),
+          ],
+          tilde: [
+            generateIssue('invalidCharacter', {
+              character: '~',
+              index: 47,
+              string: testStrings.tilde,
             }),
           ],
         }
@@ -624,43 +595,6 @@ describe('HED string and event validation', () => {
           ],
         }
         return validator(testStrings, expectedIssues)
-      })
-    })
-
-    describe('HED Tag Groups', () => {
-      const validator = function (testStrings, expectedIssues) {
-        validatorSyntacticBase(
-          testStrings,
-          expectedIssues,
-          function (parsedTestString) {
-            return hed.validateHedTagGroups(parsedTestString)
-          },
-        )
-      }
-
-      it('should have no more than two tildes', () => {
-        const testStrings = {
-          noTildeGroup:
-            'Event/Category/Experimental stimulus,(Item/Object/Vehicle/Train,Event/Category/Experimental stimulus)',
-          oneTildeGroup:
-            'Event/Category/Experimental stimulus,(Item/Object/Vehicle/Car ~ Attribute/Object control/Perturb)',
-          twoTildeGroup:
-            'Event/Category/Experimental stimulus,(Participant/ID 1 ~ Participant/Effect/Visual ~ Item/Object/Vehicle/Car, Item/ID/RedCar, Attribute/Visual/Color/Red)',
-          invalidTildeGroup:
-            'Event/Category/Experimental stimulus,(Participant/ID 1 ~ Participant/Effect/Visual ~ Item/Object/Vehicle/Car, Item/ID/RedCar, Attribute/Visual/Color/Red ~ Attribute/Object control/Perturb)',
-        }
-        const expectedIssues = {
-          noTildeGroup: [],
-          oneTildeGroup: [],
-          twoTildeGroup: [],
-          invalidTildeGroup: [
-            generateIssue('tooManyTildes', {
-              tagGroup:
-                '(Participant/ID 1 ~ Participant/Effect/Visual ~ Item/Object/Vehicle/Car, Item/ID/RedCar, Attribute/Visual/Color/Red ~ Attribute/Object control/Perturb)',
-            }),
-          ],
-        }
-        validator(testStrings, expectedIssues)
       })
     })
 

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -6,7 +6,7 @@ const generateIssue = require('../utils/issues').generateIssue
 const { Schemas } = require('../utils/schema')
 
 describe('HED string and event validation', () => {
-  describe('Latest HED schema', () => {
+  describe('Later HED-2G schemas', () => {
     const hedSchemaFile = 'tests/data/HED7.1.1.xml'
     let hedSchemaPromise
 
@@ -321,12 +321,7 @@ describe('HED string and event validation', () => {
             }),
           ],
         }
-        return validatorSemantic(
-          testStrings,
-
-          expectedIssues,
-          true,
-        )
+        return validatorSemantic(testStrings, expectedIssues, true)
       })
 
       it('should have properly capitalized names', () => {
@@ -822,7 +817,7 @@ describe('HED string and event validation', () => {
 
   const converterGenerateIssue = require('../converter/issues')
 
-  describe('Post-v8.0.0 HED schemas', () => {
+  describe('HED-3G schemas', () => {
     const hedSchemaFile = 'tests/data/HED8.0.0-alpha.1.xml'
     let hedSchemaPromise
 
@@ -831,6 +826,46 @@ describe('HED string and event validation', () => {
         path: hedSchemaFile,
       })
     })
+
+    const validatorSemanticBase = function (
+      testStrings,
+      expectedIssues,
+      testFunction,
+    ) {
+      return hedSchemaPromise.then((schemas) => {
+        for (const testStringKey in testStrings) {
+          const [parsedTestString] = stringParser.parseHedString(
+            testStrings[testStringKey],
+            schemas,
+          )
+          const testIssues = testFunction(parsedTestString, schemas)
+          assert.sameDeepMembers(
+            testIssues,
+            expectedIssues[testStringKey],
+            testStrings[testStringKey],
+          )
+        }
+      })
+    }
+
+    const validatorSyntacticBase = function (
+      testStrings,
+      expectedIssues,
+      testFunction,
+    ) {
+      for (const testStringKey in testStrings) {
+        const [parsedTestString] = stringParser.parseHedString(
+          testStrings[testStringKey],
+          new Schemas(null),
+        )
+        const testIssues = testFunction(parsedTestString)
+        assert.sameDeepMembers(
+          testIssues,
+          expectedIssues[testStringKey],
+          testStrings[testStringKey],
+        )
+      }
+    }
 
     describe('Full HED Strings', () => {
       const validator = function (testStrings, expectedIssues) {
@@ -906,6 +941,60 @@ describe('HED string and event validation', () => {
           ],
         }
         return validator(testStrings, expectedIssues)
+      })
+    })
+
+    describe('Individual HED Tags', () => {
+      const validatorSemantic = function (
+        testStrings,
+        expectedIssues,
+        checkForWarnings,
+      ) {
+        return validatorSemanticBase(
+          testStrings,
+          expectedIssues,
+          function (parsedTestString, schema) {
+            return hed.validateIndividualHedTags(
+              parsedTestString,
+              schema,
+              true,
+              checkForWarnings,
+            )
+          },
+        )
+      }
+
+      it('should exist in the schema or be an allowed extension', () => {
+        const testStrings = {
+          takesValue: 'Duration/3 ms',
+          full: 'Left-side',
+          extensionAllowed: 'Human/Driver',
+          leafExtension: 'Sensory-event/Something',
+          nonExtensionAllowed: 'Event/Nonsense',
+          illegalComma: 'Label/This is a label,This/Is/A/Tag',
+        }
+        const expectedIssues = {
+          takesValue: [],
+          full: [],
+          extensionAllowed: [
+            generateIssue('extension', { tag: testStrings.extensionAllowed }),
+          ],
+          leafExtension: [
+            generateIssue('invalidTag', { tag: testStrings.leafExtension }),
+          ],
+          nonExtensionAllowed: [
+            generateIssue('invalidTag', {
+              tag: testStrings.nonExtensionAllowed,
+            }),
+          ],
+          illegalComma: [
+            generateIssue('extraCommaOrInvalid', {
+              previousTag: 'Label/This is a label',
+              tag: 'This/Is/A/Tag',
+            }),
+          ],
+        }
+        return validatorSemantic(testStrings, expectedIssues, true)
       })
     })
   })

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -820,6 +820,8 @@ describe('HED string and event validation', () => {
     })
   })
 
+  const converterGenerateIssue = require('../converter/issues')
+
   describe('Post-v8.0.0 HED schemas', () => {
     const hedSchemaFile = 'tests/data/HED8.0.0-alpha.1.xml'
     let hedSchemaPromise
@@ -881,6 +883,26 @@ describe('HED string and event validation', () => {
             generateIssue('childRequired', {
               tag: 'Label',
             }),
+          ],
+        }
+        return validator(testStrings, expectedIssues)
+      })
+
+      it('should not validate strings with short-to-long conversion errors', () => {
+        const testStrings = {
+          // Duration/20 cm is an obviously invalid tag that should not be caught due to the first error.
+          red: 'Attribute/RGB-red, Duration/20 cm',
+        }
+        const expectedIssues = {
+          red: [
+            converterGenerateIssue(
+              'invalidParentNode',
+              'Attribute/RGB-red',
+              {
+                parentTag: 'Attribute/Sensory/Visual/Color/RGB-color/RGB-red',
+              },
+              [10, 17],
+            ),
           ],
         }
         return validator(testStrings, expectedIssues)

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -3,6 +3,7 @@ const hed = require('../validator/event')
 const schema = require('../validator/schema')
 const stringParser = require('../validator/stringParser')
 const generateIssue = require('../utils/issues').generateIssue
+const { Schemas } = require('../utils/schema')
 
 describe('HED string and event validation', () => {
   describe('Latest HED schema', () => {
@@ -22,6 +23,7 @@ describe('HED string and event validation', () => {
         for (const testStringKey in testStrings) {
           const [parsedTestString, parseIssues] = stringParser.parseHedString(
             testStrings[testStringKey],
+            schema,
           )
           const testIssues = testFunction(parsedTestString, schema)
           const issues = [].concat(parseIssues, testIssues)
@@ -42,6 +44,7 @@ describe('HED string and event validation', () => {
       for (const testStringKey in testStrings) {
         const [parsedTestString, parseIssues] = stringParser.parseHedString(
           testStrings[testStringKey],
+          new Schemas(null),
         )
         const testIssues = testFunction(parsedTestString)
         const issues = [].concat(parseIssues, testIssues)
@@ -759,6 +762,7 @@ describe('HED string and event validation', () => {
         for (const testStringKey in testStrings) {
           const [parsedTestString, parseIssues] = stringParser.parseHedString(
             testStrings[testStringKey],
+            schema,
           )
           const testIssues = testFunction(parsedTestString, schema)
           const issues = [].concat(parseIssues, testIssues)
@@ -915,7 +919,8 @@ describe('HED string and event validation', () => {
           simple: 'Car',
           groupAndValues: '(Train/Maglev,Age/15,RGB-red/0.5),Operate',
           invalidUnit: 'Duration/20 cm',
-          duplicate: 'Train,Vehicle/Train',
+          duplicateSame: 'Train,Train',
+          duplicateSimilar: 'Train,Vehicle/Train',
           missingChild: 'Label',
         }
         const legalTimeUnits = ['s', 'second', 'day', 'minute', 'hour']
@@ -924,18 +929,23 @@ describe('HED string and event validation', () => {
           groupAndValues: [],
           invalidUnit: [
             generateIssue('unitClassInvalidUnit', {
-              tag: 'Data-property/Spatiotemporal/Temporal/Duration/20 cm',
+              tag: 'Duration/20 cm',
               unitClassUnits: legalTimeUnits.sort().join(','),
             }),
           ],
-          duplicate: [
+          duplicateSame: [
+            generateIssue('duplicateTag', {
+              tag: 'Train',
+            }),
+          ],
+          duplicateSimilar: [
             generateIssue('duplicateTag', {
               tag: 'Item/Object/Man-made-object/Vehicle/Train',
             }),
           ],
           missingChild: [
             generateIssue('childRequired', {
-              tag: 'Attribute/Informational/Label',
+              tag: 'Label',
             }),
           ],
         }

--- a/tests/schema.spec.js
+++ b/tests/schema.spec.js
@@ -9,8 +9,8 @@ describe('Remote HED schemas', function() {
     const remoteHedSchemaVersion = '7.1.1'
     return schema
       .buildSchema({ version: remoteHedSchemaVersion })
-      .then(hedSchema => {
-        const hedSchemaVersion = hedSchema.version
+      .then(hedSchemas => {
+        const hedSchemaVersion = hedSchemas.baseSchema.version
         assert.strictEqual(hedSchemaVersion, remoteHedSchemaVersion)
       })
   })
@@ -18,8 +18,8 @@ describe('Remote HED schemas', function() {
 
 describe('Local HED schemas', function() {
   it('can be loaded from a file', () => {
-    return schema.buildSchema({ path: localHedSchemaFile }).then(hedSchema => {
-      const hedSchemaVersion = hedSchema.version
+    return schema.buildSchema({ path: localHedSchemaFile }).then(hedSchemas => {
+      const hedSchemaVersion = hedSchemas.baseSchema.version
       assert.strictEqual(hedSchemaVersion, localHedSchemaVersion)
     })
   })
@@ -49,8 +49,8 @@ describe('HED schemas', function() {
       'unique',
       'unitClass',
     ]
-    return hedSchemaPromise.then(hedSchema => {
-      const dictionaries = hedSchema.attributes.dictionaries
+    return hedSchemaPromise.then(hedSchemas => {
+      const dictionaries = hedSchemas.baseSchema.attributes.dictionaries
       for (const dictionaryKey of tagDictionaryKeys) {
         assert(
           dictionaries[dictionaryKey] instanceof Object,
@@ -61,20 +61,20 @@ describe('HED schemas', function() {
   })
 
   it('should contain all of the required tags', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const requiredTags = [
         'event/category',
         'event/description',
         'event/label',
       ]
       const dictionariesRequiredTags =
-        hedSchema.attributes.dictionaries['required']
+        hedSchemas.baseSchema.attributes.dictionaries['required']
       assert.sameMembers(Object.keys(dictionariesRequiredTags), requiredTags)
     })
   })
 
   it('should contain all of the positioned tags', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const positionedTags = [
         'event/category',
         'event/description',
@@ -82,7 +82,7 @@ describe('HED schemas', function() {
         'event/long name',
       ]
       const dictionariesPositionedTags =
-        hedSchema.attributes.dictionaries['position']
+        hedSchemas.baseSchema.attributes.dictionaries['position']
       assert.sameMembers(
         Object.keys(dictionariesPositionedTags),
         positionedTags,
@@ -91,15 +91,16 @@ describe('HED schemas', function() {
   })
 
   it('should contain all of the unique tags', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const uniqueTags = ['event/description', 'event/label', 'event/long name']
-      const dictionariesUniqueTags = hedSchema.attributes.dictionaries['unique']
+      const dictionariesUniqueTags =
+        hedSchemas.baseSchema.attributes.dictionaries['unique']
       assert.sameMembers(Object.keys(dictionariesUniqueTags), uniqueTags)
     })
   })
 
   it('should contain all of the tags with default units', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const defaultUnitTags = {
         'attribute/blink/time shut/#': 's',
         'attribute/blink/duration/#': 's',
@@ -107,13 +108,13 @@ describe('HED schemas', function() {
         'attribute/blink/navr/#': 'centiseconds',
       }
       const dictionariesDefaultUnitTags =
-        hedSchema.attributes.dictionaries['default']
+        hedSchemas.baseSchema.attributes.dictionaries['default']
       assert.deepStrictEqual(dictionariesDefaultUnitTags, defaultUnitTags)
     })
   })
 
   it('should contain all of the unit classes with their units and default units', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const defaultUnits = {
         acceleration: 'm-per-s^2',
         currency: '$',
@@ -152,15 +153,16 @@ describe('HED schemas', function() {
       }
 
       const dictionariesDefaultUnits =
-        hedSchema.attributes.dictionaries['defaultUnits']
-      const dictionariesAllUnits = hedSchema.attributes.dictionaries['units']
+        hedSchemas.baseSchema.attributes.dictionaries['defaultUnits']
+      const dictionariesAllUnits =
+        hedSchemas.baseSchema.attributes.dictionaries['units']
       assert.deepStrictEqual(dictionariesDefaultUnits, defaultUnits)
       assert.deepStrictEqual(dictionariesAllUnits, allUnits)
     })
   })
 
   it('should contain the correct (large) numbers of tags with certain attributes', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const expectedTagCount = {
         isNumeric: 80,
         predicateType: 20,
@@ -171,7 +173,7 @@ describe('HED schemas', function() {
         unitClass: 63,
       }
 
-      const dictionaries = hedSchema.attributes.dictionaries
+      const dictionaries = hedSchemas.baseSchema.attributes.dictionaries
       for (const attribute in expectedTagCount) {
         assert.strictEqual(
           Object.keys(dictionaries[attribute]).length,
@@ -183,7 +185,7 @@ describe('HED schemas', function() {
   })
 
   it('should identify if a tag has a certain attribute', () => {
-    return hedSchemaPromise.then(hedSchema => {
+    return hedSchemaPromise.then(hedSchemas => {
       const testStrings = {
         value:
           'Attribute/Location/Reference frame/Relative to participant/Azimuth/#',
@@ -241,7 +243,10 @@ describe('HED schemas', function() {
         const expected = expectedResults[testStringKey]
         for (const expectedKey in expected) {
           assert.strictEqual(
-            hedSchema.attributes.tagHasAttribute(testString, expectedKey),
+            hedSchemas.baseSchema.attributes.tagHasAttribute(
+              testString,
+              expectedKey,
+            ),
             expected[expectedKey],
             `Test string: ${testString}. Attribute: ${expectedKey}.`,
           )

--- a/tests/schema.spec.js
+++ b/tests/schema.spec.js
@@ -1,5 +1,6 @@
 const assert = require('chai').assert
 const schema = require('../validator/schema')
+const schemaUtils = require('../utils/schema')
 
 const localHedSchemaFile = 'tests/data/HED7.1.1.xml'
 const localHedSchemaVersion = '7.1.1'
@@ -22,6 +23,23 @@ describe('Local HED schemas', function() {
       const hedSchemaVersion = hedSchemas.baseSchema.version
       assert.strictEqual(hedSchemaVersion, localHedSchemaVersion)
     })
+  })
+})
+
+describe('Remote HED library schemas', function() {
+  it('can be loaded from a central GitHub repository', function() {
+    const remoteHedSchemaLibrary = 'test'
+    const remoteHedSchemaVersion = '0.0.1'
+    return schemaUtils
+      .loadSchema({
+        library: remoteHedSchemaLibrary,
+        version: remoteHedSchemaVersion,
+      })
+      .then(hedSchema => {
+        const schema = new schemaUtils.Schema(hedSchema)
+        assert.strictEqual(schema.library, remoteHedSchemaLibrary)
+        assert.strictEqual(schema.version, remoteHedSchemaVersion)
+      })
   })
 })
 

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -1,9 +1,32 @@
 const assert = require('chai').assert
-const stringParser = require('../validator/stringParser')
+const { Schemas } = require('../utils/schema')
+const { buildSchema } = require('../converter/schema')
+const {
+  ParsedHedTag,
+  formatHedTag,
+  hedStringIsAGroup,
+  parseHedString,
+  removeGroupParentheses,
+  splitHedString,
+} = require('../validator/stringParser')
 const generateIssue = require('../utils/issues').generateIssue
 
 describe('HED string parsing', () => {
-  const validatorWithoutIssues = function(
+  const nullSchema = new Schemas(null)
+  const originalMap = (parsedTag) => {
+    return parsedTag.originalTag
+  }
+
+  const hedSchemaFile = 'tests/data/HED8.0.0-alpha.1.xml'
+  let hedSchemaPromise
+
+  beforeAll(() => {
+    hedSchemaPromise = buildSchema({
+      path: hedSchemaFile,
+    })
+  })
+
+  const validatorWithoutIssues = function (
     testStrings,
     expectedResults,
     testFunction,
@@ -18,15 +41,14 @@ describe('HED string parsing', () => {
     }
   }
 
-  const validatorWithIssues = function(
+  const validatorWithIssues = function (
     testStrings,
     expectedResults,
     expectedIssues,
     testFunction,
   ) {
     for (const testStringKey in testStrings) {
-      const testIssues = []
-      const testResult = testFunction(testStrings[testStringKey], testIssues)
+      const [testResult, testIssues] = testFunction(testStrings[testStringKey])
       assert.sameDeepMembers(
         testResult,
         expectedResults[testStringKey],
@@ -51,17 +73,19 @@ describe('HED string parsing', () => {
           '/Attribute/Object side/Left,/Participant/Effect[/Body part/Arm',
         closingSquare:
           '/Attribute/Object side/Left,/Participant/Effect]/Body part/Arm',
+        tilde: '/Attribute/Object side/Left,/Participant/Effect~/Body part/Arm',
       }
       const expectedResultList = [
-        '/Attribute/Object side/Left',
-        '/Participant/Effect',
-        '/Body part/Arm',
+        new ParsedHedTag('/Attribute/Object side/Left', [0, 27], nullSchema),
+        new ParsedHedTag('/Participant/Effect', [28, 47], nullSchema),
+        new ParsedHedTag('/Body part/Arm', [48, 62], nullSchema),
       ]
       const expectedResults = {
         openingCurly: expectedResultList,
         closingCurly: expectedResultList,
         openingSquare: expectedResultList,
         closingSquare: expectedResultList,
+        tilde: expectedResultList,
       }
       const expectedIssues = {
         openingCurly: [
@@ -92,13 +116,20 @@ describe('HED string parsing', () => {
             string: testStrings.closingSquare,
           }),
         ],
+        tilde: [
+          generateIssue('invalidCharacter', {
+            character: '~',
+            index: 47,
+            string: testStrings.tilde,
+          }),
+        ],
       }
       validatorWithIssues(
         testStrings,
         expectedResults,
         expectedIssues,
-        (string, issues) => {
-          return stringParser.splitHedString(string, issues)
+        (string) => {
+          return splitHedString(string, nullSchema)
         },
       )
     })
@@ -106,23 +137,32 @@ describe('HED string parsing', () => {
 
   describe('HED tag groups', () => {
     it('must be surrounded by parentheses', () => {
-      const groupString =
-        '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)'
-      const nonGroupString =
-        '/Attribute/Object side/Left,/Participant/Effect/Body part/Arm'
-      const groupResult = stringParser.hedStringIsAGroup(groupString)
-      const nonGroupResult = stringParser.hedStringIsAGroup(nonGroupString)
-      assert.strictEqual(groupResult, true)
-      assert.strictEqual(nonGroupResult, false)
+      const testStrings = {
+        group:
+          '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
+        nonGroup:
+          '/Attribute/Object side/Left,/Participant/Effect/Body part/Arm',
+      }
+      const expectedResults = {
+        group: true,
+        nonGroup: false,
+      }
+      validatorWithoutIssues(testStrings, expectedResults, (string) => {
+        return hedStringIsAGroup(string)
+      })
     })
 
     it('can have its parentheses removed', () => {
-      const groupString =
-        '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)'
-      const formattedString =
-        '/Attribute/Object side/Left,/Participant/Effect/Body part/Arm'
-      const result = stringParser.removeGroupParentheses(groupString)
-      assert.strictEqual(result, formattedString)
+      const testStrings = {
+        group:
+          '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
+      }
+      const expectedResults = {
+        group: '/Attribute/Object side/Left,/Participant/Effect/Body part/Arm',
+      }
+      validatorWithoutIssues(testStrings, expectedResults, (string) => {
+        return removeGroupParentheses(string)
+      })
     })
   })
 
@@ -130,46 +170,48 @@ describe('HED string parsing', () => {
     it('should be an array', () => {
       const hedString =
         'Event/Category/Experimental stimulus,Item/Object/Vehicle/Train,Attribute/Visual/Color/Purple'
-      const issues = []
-      const result = stringParser.splitHedString(hedString, issues)
+      const [result] = splitHedString(hedString, nullSchema)
       assert(result instanceof Array)
     })
 
     it('should include each top-level tag as its own single element', () => {
       const hedString =
         'Event/Category/Experimental stimulus,Item/Object/Vehicle/Train,Attribute/Visual/Color/Purple'
-      const issues = []
-      const result = stringParser.splitHedString(hedString, issues)
+      const [result, issues] = splitHedString(hedString, nullSchema)
+      assert.deepStrictEqual(issues, [])
       assert.deepStrictEqual(result, [
-        'Event/Category/Experimental stimulus',
-        'Item/Object/Vehicle/Train',
-        'Attribute/Visual/Color/Purple',
+        new ParsedHedTag(
+          'Event/Category/Experimental stimulus',
+          [0, 36],
+          nullSchema,
+        ),
+        new ParsedHedTag('Item/Object/Vehicle/Train', [37, 62], nullSchema),
+        new ParsedHedTag('Attribute/Visual/Color/Purple', [63, 92], nullSchema),
       ])
     })
 
     it('should include each group as its own single element', () => {
       const hedString =
         '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px'
-      const issues = []
-      const result = stringParser.splitHedString(hedString, issues)
-      assert.deepStrictEqual(result, [
-        '/Action/Reach/To touch',
-        '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
-        '/Attribute/Location/Screen/Top/70 px',
-        '/Attribute/Location/Screen/Left/23 px',
-      ])
-    })
-
-    it('should handle tildes', () => {
-      const hedString =
-        '/Item/Object/Vehicle/Car ~ /Attribute/Object control/Perturb'
-      const issues = []
-      const result = stringParser.splitHedString(hedString, issues)
+      const [result, issues] = splitHedString(hedString, nullSchema)
       assert.deepStrictEqual(issues, [])
       assert.deepStrictEqual(result, [
-        '/Item/Object/Vehicle/Car',
-        '~',
-        '/Attribute/Object control/Perturb',
+        new ParsedHedTag('/Action/Reach/To touch', [0, 22], nullSchema),
+        new ParsedHedTag(
+          '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
+          [23, 86],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Attribute/Location/Screen/Top/70 px',
+          [87, 123],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Attribute/Location/Screen/Left/23 px',
+          [124, 161],
+          nullSchema,
+        ),
       ])
     })
 
@@ -178,49 +220,51 @@ describe('HED string parsing', () => {
         'Event/Category/Experimental stimulus,"Item/Object/Vehicle/Train",Attribute/Visual/Color/Purple'
       const normalString =
         'Event/Category/Experimental stimulus,Item/Object/Vehicle/Train,Attribute/Visual/Color/Purple'
-      const doubleQuoteIssues = []
-      const normalIssues = []
-      const doubleQuoteResult = stringParser.splitHedString(
+      const [doubleQuoteResult, doubleQuoteIssues] = splitHedString(
         doubleQuoteString,
-        doubleQuoteIssues,
+        nullSchema,
       )
-      const normalResult = stringParser.splitHedString(
+      const [normalResult, normalIssues] = splitHedString(
         normalString,
-        normalIssues,
+        nullSchema,
       )
       assert.deepStrictEqual(doubleQuoteIssues, [])
       assert.deepStrictEqual(normalIssues, [])
-      assert.deepStrictEqual(doubleQuoteResult, normalResult)
+      const noBoundsMap = (parsedTag) => {
+        return {
+          canonicalTag: parsedTag.canonicalTag,
+          formattedTag: parsedTag.formattedTag,
+          originalTag: parsedTag.originalTag,
+        }
+      }
+      const doubleQuoteResultNoBounds = doubleQuoteResult.map(noBoundsMap)
+      const normalResultNoBounds = normalResult.map(noBoundsMap)
+      assert.deepStrictEqual(doubleQuoteResultNoBounds, normalResultNoBounds)
     })
 
     it('should not include blanks', () => {
       const testStrings = {
-        doubleTilde:
-          '/Item/Object/Vehicle/Car~~/Attribute/Object control/Perturb',
         doubleComma:
           '/Item/Object/Vehicle/Car,,/Attribute/Object control/Perturb',
         doubleInvalidCharacter:
           '/Item/Object/Vehicle/Car[]/Attribute/Object control/Perturb',
         trailingBlank:
-          '/Item/Object/Vehicle/Car,/Attribute/Object control/Perturb,',
+          '/Item/Object/Vehicle/Car, /Attribute/Object control/Perturb,',
       }
       const expectedList = [
-        '/Item/Object/Vehicle/Car',
-        '/Attribute/Object control/Perturb',
+        new ParsedHedTag('/Item/Object/Vehicle/Car', [0, 24], nullSchema),
+        new ParsedHedTag(
+          '/Attribute/Object control/Perturb',
+          [26, 59],
+          nullSchema,
+        ),
       ]
       const expectedResults = {
-        doubleTilde: [
-          '/Item/Object/Vehicle/Car',
-          '~',
-          '~',
-          '/Attribute/Object control/Perturb',
-        ],
         doubleComma: expectedList,
         doubleInvalidCharacter: expectedList,
         trailingBlank: expectedList,
       }
       const expectedIssues = {
-        doubleTilde: [],
         doubleComma: [],
         doubleInvalidCharacter: [
           generateIssue('invalidCharacter', {
@@ -240,8 +284,8 @@ describe('HED string parsing', () => {
         testStrings,
         expectedResults,
         expectedIssues,
-        (string, issues) => {
-          return stringParser.splitHedString(string, issues)
+        (string) => {
+          return splitHedString(string, nullSchema)
         },
       )
     })
@@ -252,7 +296,7 @@ describe('HED string parsing', () => {
       // Correct formatting
       const formattedHedTag = 'event/category/experimental stimulus'
       const testStrings = {
-        formatted: 'event/category/experimental stimulus',
+        formatted: formattedHedTag,
         openingDoubleQuote: '"Event/Category/Experimental stimulus',
         closingDoubleQuote: 'Event/Category/Experimental stimulus"',
         openingAndClosingDoubleQuote: '"Event/Category/Experimental stimulus"',
@@ -282,8 +326,10 @@ describe('HED string parsing', () => {
         closingSlashOpeningDoubleQuote: formattedHedTag,
         openingAndClosingDoubleQuotedSlash: formattedHedTag,
       }
-      validatorWithoutIssues(testStrings, expectedResults, string => {
-        return stringParser.formatHedTag(string)
+      validatorWithoutIssues(testStrings, expectedResults, (string) => {
+        const parsedTag = new ParsedHedTag(string, [], nullSchema)
+        formatHedTag(parsedTag)
+        return parsedTag.formattedTag
       })
     })
   })
@@ -292,23 +338,24 @@ describe('HED string parsing', () => {
     it('must have the correct number of tags, top-level tags, and groups', () => {
       const hedString =
         '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px'
-      const [parsedString, issues] = stringParser.parseHedString(hedString)
+      const [parsedString, issues] = parseHedString(hedString, nullSchema)
       assert.deepStrictEqual(issues, [])
-      assert.sameDeepMembers(parsedString.tags, [
+      assert.sameDeepMembers(parsedString.tags.map(originalMap), [
         '/Action/Reach/To touch',
         '/Attribute/Object side/Left',
         '/Participant/Effect/Body part/Arm',
         '/Attribute/Location/Screen/Top/70 px',
         '/Attribute/Location/Screen/Left/23 px',
       ])
-      assert.sameDeepMembers(parsedString.topLevelTags, [
+      assert.sameDeepMembers(parsedString.topLevelTags.map(originalMap), [
         '/Action/Reach/To touch',
         '/Attribute/Location/Screen/Top/70 px',
         '/Attribute/Location/Screen/Left/23 px',
       ])
-      assert.sameDeepMembers(parsedString.tagGroups, [
-        ['/Attribute/Object side/Left', '/Participant/Effect/Body part/Arm'],
-      ])
+      assert.sameDeepMembers(
+        parsedString.tagGroups.map((group) => group.map(originalMap)),
+        [['/Attribute/Object side/Left', '/Participant/Effect/Body part/Arm']],
+      )
     })
 
     it('must include properly formatted tags', () => {
@@ -316,25 +363,63 @@ describe('HED string parsing', () => {
         '/Action/Reach/To touch,(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm),/Attribute/Location/Screen/Top/70 px,/Attribute/Location/Screen/Left/23 px'
       const formattedHedString =
         'action/reach/to touch,(attribute/object side/left,participant/effect/body part/arm),attribute/location/screen/top/70 px,attribute/location/screen/left/23 px'
-      const [parsedString, issues] = stringParser.parseHedString(hedString)
-      const [
-        parsedFormattedString,
-        formattedIssues,
-      ] = stringParser.parseHedString(formattedHedString)
+      const [parsedString, issues] = parseHedString(hedString, nullSchema)
+      const [parsedFormattedString, formattedIssues] = parseHedString(
+        formattedHedString,
+        nullSchema,
+      )
+      const formattedMap = (parsedTag) => {
+        return parsedTag.formattedTag
+      }
       assert.deepStrictEqual(issues, [])
       assert.deepStrictEqual(formattedIssues, [])
       assert.deepStrictEqual(
-        parsedString.formattedTags,
-        parsedFormattedString.tags,
+        parsedString.tags.map(formattedMap),
+        parsedFormattedString.tags.map(originalMap),
       )
       assert.deepStrictEqual(
-        parsedString.formattedTagGroups,
-        parsedFormattedString.tagGroups,
+        parsedString.tagGroups.map(formattedMap),
+        parsedFormattedString.tagGroups.map(originalMap),
       )
       assert.deepStrictEqual(
-        parsedString.formattedTopLevelTags,
-        parsedFormattedString.topLevelTags,
+        parsedString.topLevelTags.map(formattedMap),
+        parsedFormattedString.topLevelTags.map(originalMap),
       )
+    })
+  })
+
+  describe('Canonical HED tags', () => {
+    it('should convert HED 3 tags into canonical form', () => {
+      const testStrings = {
+        simple: 'Car',
+        groupAndTag: '(Train, RGB-red/0.5), Car',
+      }
+      const expectedResults = {
+        simple: ['Item/Object/Man-made-object/Vehicle/Car'],
+        groupAndTag: [
+          'Item/Object/Man-made-object/Vehicle/Train',
+          'Attribute/Sensory/Visual/Color/RGB-color/RGB-red/0.5',
+          'Item/Object/Man-made-object/Vehicle/Car',
+        ],
+      }
+      const expectedIssues = {
+        simple: [],
+        groupAndTag: [],
+      }
+      return hedSchemaPromise.then((hedSchema) => {
+        return validatorWithIssues(
+          testStrings,
+          expectedResults,
+          expectedIssues,
+          (string) => {
+            const [parsedString, issues] = parseHedString(string, hedSchema)
+            const canonicalTags = parsedString.tags.map((parsedTag) => {
+              return parsedTag.canonicalTag
+            })
+            return [canonicalTags, issues]
+          },
+        )
+      })
     })
   })
 })

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -76,9 +76,24 @@ describe('HED string parsing', () => {
         tilde: '/Attribute/Object side/Left,/Participant/Effect~/Body part/Arm',
       }
       const expectedResultList = [
-        new ParsedHedTag('/Attribute/Object side/Left', [0, 27], nullSchema),
-        new ParsedHedTag('/Participant/Effect', [28, 47], nullSchema),
-        new ParsedHedTag('/Body part/Arm', [48, 62], nullSchema),
+        new ParsedHedTag(
+          '/Attribute/Object side/Left',
+          '/Attribute/Object side/Left',
+          [0, 27],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Participant/Effect',
+          '/Participant/Effect',
+          [28, 47],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Body part/Arm',
+          '/Body part/Arm',
+          [48, 62],
+          nullSchema,
+        ),
       ]
       const expectedResults = {
         openingCurly: expectedResultList,
@@ -182,11 +197,22 @@ describe('HED string parsing', () => {
       assert.deepStrictEqual(result, [
         new ParsedHedTag(
           'Event/Category/Experimental stimulus',
+          'Event/Category/Experimental stimulus',
           [0, 36],
           nullSchema,
         ),
-        new ParsedHedTag('Item/Object/Vehicle/Train', [37, 62], nullSchema),
-        new ParsedHedTag('Attribute/Visual/Color/Purple', [63, 92], nullSchema),
+        new ParsedHedTag(
+          'Item/Object/Vehicle/Train',
+          'Item/Object/Vehicle/Train',
+          [37, 62],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          'Attribute/Visual/Color/Purple',
+          'Attribute/Visual/Color/Purple',
+          [63, 92],
+          nullSchema,
+        ),
       ])
     })
 
@@ -196,18 +222,26 @@ describe('HED string parsing', () => {
       const [result, issues] = splitHedString(hedString, nullSchema)
       assert.deepStrictEqual(issues, [])
       assert.deepStrictEqual(result, [
-        new ParsedHedTag('/Action/Reach/To touch', [0, 22], nullSchema),
         new ParsedHedTag(
+          '/Action/Reach/To touch',
+          '/Action/Reach/To touch',
+          [0, 22],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
           '(/Attribute/Object side/Left,/Participant/Effect/Body part/Arm)',
           [23, 86],
           nullSchema,
         ),
         new ParsedHedTag(
           '/Attribute/Location/Screen/Top/70 px',
+          '/Attribute/Location/Screen/Top/70 px',
           [87, 123],
           nullSchema,
         ),
         new ParsedHedTag(
+          '/Attribute/Location/Screen/Left/23 px',
           '/Attribute/Location/Screen/Left/23 px',
           [124, 161],
           nullSchema,
@@ -252,8 +286,14 @@ describe('HED string parsing', () => {
           '/Item/Object/Vehicle/Car, /Attribute/Object control/Perturb,',
       }
       const expectedList = [
-        new ParsedHedTag('/Item/Object/Vehicle/Car', [0, 24], nullSchema),
         new ParsedHedTag(
+          '/Item/Object/Vehicle/Car',
+          '/Item/Object/Vehicle/Car',
+          [0, 24],
+          nullSchema,
+        ),
+        new ParsedHedTag(
+          '/Attribute/Object control/Perturb',
           '/Attribute/Object control/Perturb',
           [26, 59],
           nullSchema,
@@ -327,7 +367,7 @@ describe('HED string parsing', () => {
         openingAndClosingDoubleQuotedSlash: formattedHedTag,
       }
       validatorWithoutIssues(testStrings, expectedResults, (string) => {
-        const parsedTag = new ParsedHedTag(string, [], nullSchema)
+        const parsedTag = new ParsedHedTag(string, string, [], nullSchema)
         formatHedTag(parsedTag)
         return parsedTag.formattedTag
       })

--- a/utils/__tests__/hed.spec.js
+++ b/utils/__tests__/hed.spec.js
@@ -175,8 +175,8 @@ describe('HED tag string utility functions', () => {
       return validatorString(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.tagExistsInSchema(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.tagExistsInSchema(string, hedSchemas.baseSchema.attributes)
         },
       )
     })
@@ -201,8 +201,8 @@ describe('HED tag string utility functions', () => {
       return validatorString(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.tagTakesValue(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.tagTakesValue(string, hedSchemas.baseSchema.attributes)
         },
       )
     })
@@ -227,8 +227,8 @@ describe('HED tag string utility functions', () => {
       return validatorString(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.isUnitClassTag(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.isUnitClassTag(string, hedSchemas.baseSchema.attributes)
         },
       )
     })
@@ -256,8 +256,11 @@ describe('HED tag string utility functions', () => {
       return validatorString(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.getUnitClassDefaultUnit(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.getUnitClassDefaultUnit(
+            string,
+            hedSchemas.baseSchema.attributes,
+          )
         },
       )
     })
@@ -285,8 +288,8 @@ describe('HED tag string utility functions', () => {
       return validatorList(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.getTagUnitClasses(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.getTagUnitClasses(string, hedSchemas.baseSchema.attributes)
         },
       )
     })
@@ -327,8 +330,11 @@ describe('HED tag string utility functions', () => {
       return validatorList(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.getTagUnitClassUnits(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.getTagUnitClassUnits(
+            string,
+            hedSchemas.baseSchema.attributes,
+          )
         },
       )
     })
@@ -340,30 +346,30 @@ describe('HED tag string utility functions', () => {
       const invalidVolumeString = '200 cm'
       const currencyUnits = ['dollars', '$', 'points', 'fraction']
       const volumeUnits = ['m^3']
-      return hedSchemaPromise.then(hedSchema => {
+      return hedSchemaPromise.then(hedSchemas => {
         const strippedDollarsString = hed.validateUnits(
           dollarsString,
           dollarsString,
           currencyUnits,
-          hedSchema.attributes,
+          hedSchemas.baseSchema.attributes,
         )
         const strippedVolumeString = hed.validateUnits(
           volumeString,
           volumeString,
           volumeUnits,
-          hedSchema.attributes,
+          hedSchemas.baseSchema.attributes,
         )
         const strippedPrefixedVolumeString = hed.validateUnits(
           prefixedVolumeString,
           prefixedVolumeString,
           volumeUnits,
-          hedSchema.attributes,
+          hedSchemas.baseSchema.attributes,
         )
         const strippedInvalidVolumeString = hed.validateUnits(
           invalidVolumeString,
           invalidVolumeString,
           volumeUnits,
-          hedSchema.attributes,
+          hedSchemas.baseSchema.attributes,
         )
         assert.strictEqual(strippedDollarsString, '25.99')
         assert.strictEqual(strippedVolumeString, '100')
@@ -386,8 +392,11 @@ describe('HED tag string utility functions', () => {
       return validatorString(
         testStrings,
         expectedResults,
-        (string, hedSchema) => {
-          return hed.isExtensionAllowedTag(string, hedSchema.attributes)
+        (string, hedSchemas) => {
+          return hed.isExtensionAllowedTag(
+            string,
+            hedSchemas.baseSchema.attributes,
+          )
         },
       )
     })

--- a/utils/__tests__/string.spec.js
+++ b/utils/__tests__/string.spec.js
@@ -1,134 +1,176 @@
 const assert = require('assert')
 const utils = require('../')
 
-describe('Blank strings', function() {
-  it('may be empty', function() {
-    const emptyString = ''
-    const result = utils.string.stringIsEmpty(emptyString)
-    assert.strictEqual(result, true)
+describe('String utility functions', () => {
+  describe('Blank strings', () => {
+    it('may be empty', () => {
+      const emptyString = ''
+      const result = utils.string.stringIsEmpty(emptyString)
+      assert.strictEqual(result, true)
+    })
+
+    it('may have only whitespace', () => {
+      const spaceString = ' \n  \t  '
+      const result = utils.string.stringIsEmpty(spaceString)
+      assert.strictEqual(result, true)
+    })
+
+    it('may not contain letters', () => {
+      const aString = 'a'
+      const result = utils.string.stringIsEmpty(aString)
+      assert.strictEqual(result, false)
+    })
+
+    it('may not contain numbers', () => {
+      const oneString = '1'
+      const result = utils.string.stringIsEmpty(oneString)
+      assert.strictEqual(result, false)
+    })
+
+    it('may not contain punctuation', () => {
+      const slashString = '/'
+      const result = utils.string.stringIsEmpty(slashString)
+      assert.strictEqual(result, false)
+    })
   })
 
-  it('may have only whitespace', function() {
-    const spaceString = ' \n  \t  '
-    const result = utils.string.stringIsEmpty(spaceString)
-    assert.strictEqual(result, true)
+  describe('Capitalized strings', () => {
+    it('must have a capitalized first letter', () => {
+      const testString = 'to be'
+      const result = utils.string.capitalizeString(testString)
+      assert.strictEqual(result, 'To be')
+    })
+
+    it('must not change letters after the first letter', () => {
+      const testString = 'to BE or NOT to BE'
+      const result = utils.string.capitalizeString(testString)
+      assert.strictEqual(result, 'To BE or NOT to BE')
+    })
   })
 
-  it('may not contain letters', function() {
-    const aString = 'a'
-    const result = utils.string.stringIsEmpty(aString)
-    assert.strictEqual(result, false)
+  describe('Character counts', () => {
+    it('must be correct', () => {
+      const testString = 'abcabcaaabccccdddfdddd'
+      const resultA = utils.string.getCharacterCount(testString, 'a')
+      const resultB = utils.string.getCharacterCount(testString, 'b')
+      const resultC = utils.string.getCharacterCount(testString, 'c')
+      const resultD = utils.string.getCharacterCount(testString, 'd')
+      const resultE = utils.string.getCharacterCount(testString, 'e')
+      const resultF = utils.string.getCharacterCount(testString, 'f')
+      assert.strictEqual(resultA, 5)
+      assert.strictEqual(resultB, 3)
+      assert.strictEqual(resultC, 6)
+      assert.strictEqual(resultD, 7)
+      assert.strictEqual(resultE, 0)
+      assert.strictEqual(resultF, 1)
+    })
   })
 
-  it('may not contain numbers', function() {
-    const oneString = '1'
-    const result = utils.string.stringIsEmpty(oneString)
-    assert.strictEqual(result, false)
+  describe('Valid HED times', () => {
+    it('must be of the form HH:MM or HH:MM:SS', () => {
+      const validTestStrings = {
+        validPM: '23:52',
+        validMidnight: '00:55',
+        validHour: '11:00',
+        validSingleDigitHour: '08:30',
+        validSeconds: '19:33:47',
+      }
+      const invalidTestStrings = {
+        invalidDate: '8/8/2019',
+        invalidHour: '25:11',
+        invalidSingleDigitHour: '8:30',
+        invalidMinute: '12:65',
+        invalidSecond: '15:45:82',
+        invalidTimeZone: '16:25:51+00:00',
+        invalidMilliseconds: '17:31:05.123',
+        invalidMicroseconds: '09:21:16.123456',
+        invalidDateTime: '2000-01-01T00:55:00',
+        invalidString: 'not a time',
+      }
+      for (const key in validTestStrings) {
+        const string = validTestStrings[key]
+        const result = utils.string.isClockFaceTime(string)
+        assert.strictEqual(result, true, string)
+      }
+      for (const key in invalidTestStrings) {
+        const string = invalidTestStrings[key]
+        const result = utils.string.isClockFaceTime(string)
+        assert.strictEqual(result, false, string)
+      }
+    })
   })
 
-  it('may not contain punctuation', function() {
-    const slashString = '/'
-    const result = utils.string.stringIsEmpty(slashString)
-    assert.strictEqual(result, false)
+  describe('Valid HED date-times', () => {
+    it('must be in ISO 8601 format', () => {
+      const validTestStrings = {
+        validPM: '2000-01-01T23:52:00',
+        validMidnight: '2000-01-01T00:55:00',
+        validHour: '2000-01-01T11:00:00',
+        validSingleDigitHour: '2000-01-01T08:30:00',
+        validSeconds: '2000-01-01T19:33:47',
+        validMilliseconds: '2000-01-01T17:31:05.123',
+        validMicroseconds: '2000-01-01T09:21:16.123456',
+      }
+      const invalidTestStrings = {
+        invalidDate: '8/8/2019',
+        invalidTime: '00:55:00',
+        invalidHour: '2000-01-01T25:11',
+        invalidSingleDigitHour: '2000-01-01T8:30',
+        invalidMinute: '2000-01-01T12:65',
+        invalidSecond: '2000-01-01T15:45:82',
+        invalidTimeZone: '2000-01-01T16:25:51+00:00',
+        invalidString: 'not a time',
+      }
+      for (const key in validTestStrings) {
+        const string = validTestStrings[key]
+        const result = utils.string.isDateTime(string)
+        assert.strictEqual(result, true, string)
+      }
+      for (const key in invalidTestStrings) {
+        const string = invalidTestStrings[key]
+        const result = utils.string.isDateTime(string)
+        assert.strictEqual(result, false, string)
+      }
+    })
   })
-})
 
-describe('Capitalized strings', function() {
-  it('must have a capitalized first letter', function() {
-    const testString = 'to be'
-    const result = utils.string.capitalizeString(testString)
-    assert.strictEqual(result, 'To be')
-  })
-
-  it('must not change letters after the first letter', function() {
-    const testString = 'to BE or NOT to BE'
-    const result = utils.string.capitalizeString(testString)
-    assert.strictEqual(result, 'To BE or NOT to BE')
-  })
-})
-
-describe('Character counts', function() {
-  it('must be correct', function() {
-    const testString = 'abcabcaaabccccdddfdddd'
-    const resultA = utils.string.getCharacterCount(testString, 'a')
-    const resultB = utils.string.getCharacterCount(testString, 'b')
-    const resultC = utils.string.getCharacterCount(testString, 'c')
-    const resultD = utils.string.getCharacterCount(testString, 'd')
-    const resultE = utils.string.getCharacterCount(testString, 'e')
-    const resultF = utils.string.getCharacterCount(testString, 'f')
-    assert.strictEqual(resultA, 5)
-    assert.strictEqual(resultB, 3)
-    assert.strictEqual(resultC, 6)
-    assert.strictEqual(resultD, 7)
-    assert.strictEqual(resultE, 0)
-    assert.strictEqual(resultF, 1)
-  })
-})
-
-describe('Valid HED times', function() {
-  it('must be of the form HH:MM or HH:MM:SS', function() {
-    const validTestStrings = {
-      validPM: '23:52',
-      validMidnight: '00:55',
-      validHour: '11:00',
-      validSingleDigitHour: '08:30',
-      validSeconds: '19:33:47',
-    }
-    const invalidTestStrings = {
-      invalidDate: '8/8/2019',
-      invalidHour: '25:11',
-      invalidSingleDigitHour: '8:30',
-      invalidMinute: '12:65',
-      invalidSecond: '15:45:82',
-      invalidTimeZone: '16:25:51+00:00',
-      invalidMilliseconds: '17:31:05.123',
-      invalidMicroseconds: '09:21:16.123456',
-      invalidDateTime: '2000-01-01T00:55:00',
-      invalidString: 'not a time',
-    }
-    for (const key in validTestStrings) {
-      const string = validTestStrings[key]
-      const result = utils.string.isClockFaceTime(string)
-      assert.strictEqual(result, true, string)
-    }
-    for (const key in invalidTestStrings) {
-      const string = invalidTestStrings[key]
-      const result = utils.string.isClockFaceTime(string)
-      assert.strictEqual(result, false, string)
-    }
-  })
-})
-
-describe('Valid HED date-times', function() {
-  it('must be in ISO 8601 format', function() {
-    const validTestStrings = {
-      validPM: '2000-01-01T23:52:00',
-      validMidnight: '2000-01-01T00:55:00',
-      validHour: '2000-01-01T11:00:00',
-      validSingleDigitHour: '2000-01-01T08:30:00',
-      validSeconds: '2000-01-01T19:33:47',
-      validMilliseconds: '2000-01-01T17:31:05.123',
-      validMicroseconds: '2000-01-01T09:21:16.123456',
-    }
-    const invalidTestStrings = {
-      invalidDate: '8/8/2019',
-      invalidTime: '00:55:00',
-      invalidHour: '2000-01-01T25:11',
-      invalidSingleDigitHour: '2000-01-01T8:30',
-      invalidMinute: '2000-01-01T12:65',
-      invalidSecond: '2000-01-01T15:45:82',
-      invalidTimeZone: '2000-01-01T16:25:51+00:00',
-      invalidString: 'not a time',
-    }
-    for (const key in validTestStrings) {
-      const string = validTestStrings[key]
-      const result = utils.string.isDateTime(string)
-      assert.strictEqual(result, true, string)
-    }
-    for (const key in invalidTestStrings) {
-      const string = invalidTestStrings[key]
-      const result = utils.string.isDateTime(string)
-      assert.strictEqual(result, false, string)
-    }
+  describe('Valid HED numbers', () => {
+    it('must be in scientific notation', () => {
+      const validTestStrings = {
+        validPositiveInteger: '21',
+        validNegativeInteger: '-500',
+        validPositiveDecimal: '8520.63',
+        validNegativeDecimal: '-945.61',
+        validPositiveFractional: '0.84',
+        validNegativeFractional: '-0.61',
+        validPositiveScientificInteger: '21e10',
+        validNegativeScientificInteger: '-500E-5',
+        validPositiveScientificDecimal: '8520.63E15',
+        validNegativeScientificDecimal: '-945.61e-3',
+        validPositiveScientificFractional: '0.84e-2',
+        validNegativeScientificFractional: '-0.61E5',
+      }
+      const invalidTestStrings = {
+        invalidDecimalPoint: '.',
+        invalidMultipleDecimalPoints: '22.88.66',
+        invalidMultipleEs: '888ee66',
+        invalidStartCharacter: 'e77e6',
+        invalidBlankExponent: '432e',
+        invalidBlankNegativeExponent: '1853e-',
+        invalidStartingDecimalPoint: '.852',
+        invalidEndingDecimalPoint: '851695.',
+        invalidOtherCharacter: '81468g516',
+      }
+      for (const key in validTestStrings) {
+        const string = validTestStrings[key]
+        const result = utils.string.isNumber(string)
+        assert.strictEqual(result, true, string)
+      }
+      for (const key in invalidTestStrings) {
+        const string = invalidTestStrings[key]
+        const result = utils.string.isNumber(string)
+        assert.strictEqual(result, false, string)
+      }
+    })
   })
 })

--- a/utils/hed.js
+++ b/utils/hed.js
@@ -1,6 +1,8 @@
 const pluralize = require('pluralize')
 pluralize.addUncountableRule('hertz')
 
+const { isNumber } = require('./string')
+
 const defaultUnitForTagAttribute = 'default'
 const defaultUnitsForUnitClassAttribute = 'defaultUnits'
 const extensionAllowedAttribute = 'extensionAllowed'
@@ -16,7 +18,7 @@ const SIUnitSymbolModifierKey = 'SIUnitSymbolModifier'
 /**
  * Replace the end of a HED tag with a pound sign.
  */
-const replaceTagNameWithPound = function(formattedTag) {
+const replaceTagNameWithPound = function (formattedTag) {
   const lastTagSlashIndex = formattedTag.lastIndexOf('/')
   if (lastTagSlashIndex !== -1) {
     return formattedTag.substring(0, lastTagSlashIndex) + '/#'
@@ -28,7 +30,7 @@ const replaceTagNameWithPound = function(formattedTag) {
 /**
  * Get the indices of all slashes in a HED tag.
  */
-const getTagSlashIndices = function(tag) {
+const getTagSlashIndices = function (tag) {
   const indices = []
   let i = -1
   while ((i = tag.indexOf('/', i + 1)) >= 0) {
@@ -40,7 +42,7 @@ const getTagSlashIndices = function(tag) {
 /**
  * Get the last part of a HED tag.
  */
-const getTagName = function(tag) {
+const getTagName = function (tag) {
   const lastSlashIndex = tag.lastIndexOf('/')
   if (lastSlashIndex === -1) {
     return tag
@@ -52,7 +54,7 @@ const getTagName = function(tag) {
 /**
  * Get the HED tag prefix (up to the last slash).
  */
-const getParentTag = function(tag) {
+const getParentTag = function (tag) {
   const lastSlashIndex = tag.lastIndexOf('/')
   if (lastSlashIndex === -1) {
     return tag
@@ -61,19 +63,17 @@ const getParentTag = function(tag) {
   }
 }
 
-const digitExpression = /^-?[\d.]+(?:[Ee]-?\d+)?$/
-
 /**
  * Determine if a stripped value is valid.
  */
-const validateValue = function(value, allowPlaceholders) {
-  return digitExpression.test(value) || (allowPlaceholders && value === '#')
+const validateValue = function (value, allowPlaceholders) {
+  return isNumber(value) || (allowPlaceholders && value === '#')
 }
 
 /**
  * Get the list of valid derivatives of a unit.
  */
-const getValidUnitPlural = function(unit, hedSchemaAttributes) {
+const getValidUnitPlural = function (unit, hedSchemaAttributes) {
   const derivativeUnits = [unit]
   if (
     hedSchemaAttributes.hasUnitModifiers &&
@@ -87,7 +87,7 @@ const getValidUnitPlural = function(unit, hedSchemaAttributes) {
 /**
  * Check for a valid unit and remove it.
  */
-const stripOffUnitsIfValid = function(
+const stripOffUnitsIfValid = function (
   tagUnitValue,
   hedSchemaAttributes,
   originalUnit,
@@ -103,7 +103,8 @@ const stripOffUnitsIfValid = function(
     foundUnit = true
     strippedValue = tagUnitValue.slice(0, -originalUnit.length).trim()
   }
-  const isSIUnit = hedSchemaAttributes.dictionaries[SIUnitKey][normalizedUnit] !== undefined
+  const isSIUnit =
+    hedSchemaAttributes.dictionaries[SIUnitKey][normalizedUnit] !== undefined
   if (foundUnit && isSIUnit && hedSchemaAttributes.hasUnitModifiers) {
     const modifierKey = isUnitSymbol
       ? SIUnitSymbolModifierKey
@@ -122,7 +123,7 @@ const stripOffUnitsIfValid = function(
 /**
  * Validate a unit and strip it from the value.
  */
-const validateUnits = function(
+const validateUnits = function (
   originalTagUnitValue,
   formattedTagUnitValue,
   tagUnitClassUnits,
@@ -166,14 +167,14 @@ const validateUnits = function(
 /**
  * Determine if a HED tag is in the schema.
  */
-const tagExistsInSchema = function(formattedTag, hedSchemaAttributes) {
+const tagExistsInSchema = function (formattedTag, hedSchemaAttributes) {
   return formattedTag in hedSchemaAttributes.dictionaries[tagsDictionaryKey]
 }
 
 /**
  * Checks if a HED tag has the 'takesValue' attribute.
  */
-const tagTakesValue = function(formattedTag, hedSchemaAttributes) {
+const tagTakesValue = function (formattedTag, hedSchemaAttributes) {
   const takesValueTag = replaceTagNameWithPound(formattedTag)
   return hedSchemaAttributes.tagHasAttribute(takesValueTag, takesValueType)
 }
@@ -181,7 +182,7 @@ const tagTakesValue = function(formattedTag, hedSchemaAttributes) {
 /**
  * Checks if a HED tag has the 'unitClass' attribute.
  */
-const isUnitClassTag = function(formattedTag, hedSchemaAttributes) {
+const isUnitClassTag = function (formattedTag, hedSchemaAttributes) {
   if (!hedSchemaAttributes.hasUnitClasses) {
     return false
   }
@@ -192,7 +193,7 @@ const isUnitClassTag = function(formattedTag, hedSchemaAttributes) {
 /**
  * Get the default unit for a particular HED tag.
  */
-const getUnitClassDefaultUnit = function(formattedTag, hedSchemaAttributes) {
+const getUnitClassDefaultUnit = function (formattedTag, hedSchemaAttributes) {
   if (isUnitClassTag(formattedTag, hedSchemaAttributes)) {
     const unitClassTag = replaceTagNameWithPound(formattedTag)
     const hasDefaultAttribute = hedSchemaAttributes.tagHasAttribute(
@@ -206,9 +207,8 @@ const getUnitClassDefaultUnit = function(formattedTag, hedSchemaAttributes) {
     } else if (
       unitClassTag in hedSchemaAttributes.dictionaries[unitClassType]
     ) {
-      const unitClasses = hedSchemaAttributes.dictionaries[unitClassType][
-        unitClassTag
-      ].split(',')
+      const unitClasses =
+        hedSchemaAttributes.dictionaries[unitClassType][unitClassTag].split(',')
       const firstUnitClass = unitClasses[0]
       return hedSchemaAttributes.dictionaries[
         defaultUnitsForUnitClassAttribute
@@ -222,7 +222,7 @@ const getUnitClassDefaultUnit = function(formattedTag, hedSchemaAttributes) {
 /**
  * Get the unit classes for a particular HED tag.
  */
-const getTagUnitClasses = function(formattedTag, hedSchemaAttributes) {
+const getTagUnitClasses = function (formattedTag, hedSchemaAttributes) {
   if (isUnitClassTag(formattedTag, hedSchemaAttributes)) {
     const unitClassTag = replaceTagNameWithPound(formattedTag)
     const unitClassesString =
@@ -236,7 +236,7 @@ const getTagUnitClasses = function(formattedTag, hedSchemaAttributes) {
 /**
  * Get the legal units for a particular HED tag.
  */
-const getTagUnitClassUnits = function(formattedTag, hedSchemaAttributes) {
+const getTagUnitClassUnits = function (formattedTag, hedSchemaAttributes) {
   const tagUnitClasses = getTagUnitClasses(formattedTag, hedSchemaAttributes)
   const units = []
   for (const unitClass of tagUnitClasses) {
@@ -250,7 +250,7 @@ const getTagUnitClassUnits = function(formattedTag, hedSchemaAttributes) {
 /**
  * Check if any level of a HED tag allows extensions.
  */
-const isExtensionAllowedTag = function(formattedTag, hedSchemaAttributes) {
+const isExtensionAllowedTag = function (formattedTag, hedSchemaAttributes) {
   if (
     hedSchemaAttributes.tagHasAttribute(formattedTag, extensionAllowedAttribute)
   ) {

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -85,6 +85,15 @@ const generateIssue = function (code, parameters) {
     case 'duplicateTagsInSchema':
       message = `ERROR: Source HED schema is invalid as it contains duplicate tags.`
       break
+    case 'illegalDefinitionGroupTag':
+      message = `ERROR: Illegal tag "${parameters.tag}" in tag group for definition "${parameters.definition}"`
+      break
+    case 'nestedDefinition':
+      message = `ERROR: Illegal nested definition in tag group for definition "${parameters.definition}"`
+      break
+    case 'multipleTagGroupsInDefinition':
+      message = `ERROR: Multiple inner tag groups found in definition "${parameters.definition}"`
+      break
     default:
       message = `ERROR: Unknown HED error.`
       break

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -94,6 +94,9 @@ const generateIssue = function (code, parameters) {
     case 'multipleTagGroupsInDefinition':
       message = `ERROR: Multiple inner tag groups found in definition "${parameters.definition}"`
       break
+    case 'topLevelDefinitionTag':
+      message = `ERROR: Illegal top-level definition tag - "${parameters.tag}"`
+      break
     default:
       message = `ERROR: Unknown HED error.`
       break

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -5,7 +5,7 @@ const files = require('../utils/files')
 /**
  * Load schema XML data from a schema version or path description.
  *
- * @param {{path: string?, version: string?}} schemaDef The description of which schema to use.
+ * @param {{path: string?, library: string?, version: string?}} schemaDef The description of which schema to use.
  * @return {Promise<never>|Promise<object>} The schema XML data or an error.
  */
 const loadSchema = function(schemaDef = {}) {
@@ -13,6 +13,8 @@ const loadSchema = function(schemaDef = {}) {
     return loadRemoteSchema()
   } else if (schemaDef.path) {
     return loadLocalSchema(schemaDef.path)
+  } else if (schemaDef.library) {
+    return loadRemoteSchema(schemaDef.version, schemaDef.library)
   } else if (schemaDef.version) {
     return loadRemoteSchema(schemaDef.version)
   } else {
@@ -24,12 +26,21 @@ const loadSchema = function(schemaDef = {}) {
  * Load schema XML data from the HED specification GitHub repository.
  *
  * @param {string} version The schema version to load.
+ * @param {string?} library The library schema to load.
  * @return {Promise<object>} The schema XML data.
  */
-const loadRemoteSchema = function(version = 'Latest') {
-  const fileName = 'HED' + version + '.xml'
-  const basePath =
-    'https://raw.githubusercontent.com/hed-standard/hed-specification/master/hedxml/'
+const loadRemoteSchema = function(version = 'Latest', library) {
+  let fileName
+  let basePath
+  if (library) {
+    fileName = 'HED_' + library + '_' + version + '.xml'
+    basePath =
+      'https://raw.githubusercontent.com/hed-standard/hed-schema-library/master/hedxml/'
+  } else {
+    fileName = 'HED' + version + '.xml'
+    basePath =
+      'https://raw.githubusercontent.com/hed-standard/hed-specification/master/hedxml/'
+  }
   const url = basePath + fileName
   return files
     .readHTTPSFile(url)
@@ -105,6 +116,11 @@ const Schema = function(xmlData, attributes, mapping) {
    * @type {string}
    */
   this.version = rootElement.$.version
+  /**
+   * The HED library schema name.
+   * @type {string|undefined}
+   */
+  this.library = rootElement.$.library
   /**
    * The description of tag attributes.
    * @type {SchemaAttributes}

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -1,3 +1,4 @@
+const semver = require('semver')
 const xml2js = require('xml2js')
 
 const files = require('../utils/files')
@@ -104,7 +105,7 @@ const setParent = function(node, parent) {
  * @param {Mapping} mapping A mapping between short and long tags.
  * @constructor
  */
-const Schema = function(xmlData, attributes, mapping) {
+const Schema = function (xmlData, attributes, mapping) {
   /**
    * The schema XML data.
    * @type {Object}
@@ -139,7 +140,7 @@ const Schema = function(xmlData, attributes, mapping) {
  * @param {Schema} baseSchema The base HED schema.
  * @constructor
  */
-const Schemas = function(baseSchema) {
+const Schemas = function (baseSchema) {
   /**
    * The base HED schema.
    * @type {Schema}
@@ -150,6 +151,11 @@ const Schemas = function(baseSchema) {
    * @type {Object<string, Schema>}
    */
   this.librarySchemas = {}
+  /**
+   * Whether this is a HED 3 schema collection.
+   * @type {boolean}
+   */
+  this.isHed3 = baseSchema && semver.gte(baseSchema.version, '8.0.0-alpha')
 }
 
 module.exports = {

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -9,7 +9,7 @@ const files = require('../utils/files')
  * @param {{path: string?, library: string?, version: string?}} schemaDef The description of which schema to use.
  * @return {Promise<never>|Promise<object>} The schema XML data or an error.
  */
-const loadSchema = function(schemaDef = {}) {
+const loadSchema = function (schemaDef = {}) {
   if (Object.entries(schemaDef).length === 0) {
     return loadRemoteSchema()
   } else if (schemaDef.path) {
@@ -30,7 +30,7 @@ const loadSchema = function(schemaDef = {}) {
  * @param {string?} library The library schema to load.
  * @return {Promise<object>} The schema XML data.
  */
-const loadRemoteSchema = function(version = 'Latest', library) {
+const loadRemoteSchema = function (version = 'Latest', library) {
   let fileName
   let basePath
   if (library) {
@@ -45,10 +45,10 @@ const loadRemoteSchema = function(version = 'Latest', library) {
   const url = basePath + fileName
   return files
     .readHTTPSFile(url)
-    .then(data => {
+    .then((data) => {
       return xml2js.parseStringPromise(data, { explicitCharkey: true })
     })
-    .catch(error => {
+    .catch((error) => {
       throw new Error(
         'Could not load HED schema version "' +
           version +
@@ -65,13 +65,13 @@ const loadRemoteSchema = function(version = 'Latest', library) {
  * @param {string} path The path to the schema XML data.
  * @return {Promise<object>} The schema XML data.
  */
-const loadLocalSchema = function(path) {
+const loadLocalSchema = function (path) {
   return files
     .readFile(path)
-    .then(data => {
+    .then((data) => {
       return xml2js.parseStringPromise(data, { explicitCharkey: true })
     })
-    .catch(error => {
+    .catch((error) => {
       throw new Error(
         'Could not load HED schema from path "' + path + '" - "' + error + '".',
       )
@@ -84,7 +84,7 @@ const loadLocalSchema = function(path) {
  * @param {object} node The child node.
  * @param {object} parent The parent node.
  */
-const setParent = function(node, parent) {
+const setParent = function (node, parent) {
   // Assume that we've already run this function if so.
   if ('$parent' in node) {
     return

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -88,12 +88,16 @@ const setParent = function(node, parent) {
 /**
  * An imported HED schema object.
  *
- * @param {object} xmlData The schema XML data.
+ * @param {Object} xmlData The schema XML data.
  * @param {SchemaAttributes} attributes A description of tag attributes.
  * @param {Mapping} mapping A mapping between short and long tags.
  * @constructor
  */
 const Schema = function(xmlData, attributes, mapping) {
+  /**
+   * The schema XML data.
+   * @type {Object}
+   */
   this.xmlData = xmlData
   const rootElement = xmlData.HED
   /**
@@ -101,12 +105,40 @@ const Schema = function(xmlData, attributes, mapping) {
    * @type {string}
    */
   this.version = rootElement.$.version
+  /**
+   * The description of tag attributes.
+   * @type {SchemaAttributes}
+   */
   this.attributes = attributes
+  /**
+   * The mapping between short and long tags.
+   * @type {Mapping}
+   */
   this.mapping = mapping
+}
+
+/**
+ * The collection of active HED schemas.
+ *
+ * @param {Schema} baseSchema The base HED schema.
+ * @constructor
+ */
+const Schemas = function(baseSchema) {
+  /**
+   * The base HED schema.
+   * @type {Schema}
+   */
+  this.baseSchema = baseSchema
+  /**
+   * The imported library HED schemas.
+   * @type {Object<string, Schema>}
+   */
+  this.librarySchemas = {}
 }
 
 module.exports = {
   loadSchema: loadSchema,
   setParent: setParent,
   Schema: Schema,
+  Schemas: Schemas,
 }

--- a/utils/string.js
+++ b/utils/string.js
@@ -2,6 +2,7 @@ const date = require('date-and-time')
 const parseISO = require('date-fns/parseISO')
 const dateIsValid = require('date-fns/isValid')
 const rfc3339ish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?$/
+const digitExpression = /^-?\d+(?:\.\d+)?(?:[Ee]-?\d+)?$/
 
 /**
  * Check if a string is empty or only whitespace.
@@ -9,7 +10,7 @@ const rfc3339ish = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?$/
  * @param {string} string The string to check.
  * @returns {boolean} Whether the string is empty.
  */
-const stringIsEmpty = function(string) {
+const stringIsEmpty = function (string) {
   return !string.trim()
 }
 
@@ -20,7 +21,7 @@ const stringIsEmpty = function(string) {
  * @param {string} characterToCount The character to search for.
  * @returns {number} The number of instances of the character in the string.
  */
-const getCharacterCount = function(string, characterToCount) {
+const getCharacterCount = function (string, characterToCount) {
   return string.split(characterToCount).length - 1
 }
 
@@ -30,7 +31,7 @@ const getCharacterCount = function(string, characterToCount) {
  * @param {string} string The string to capitalize.
  * @returns {string} The capitalized string.
  */
-const capitalizeString = function(string) {
+const capitalizeString = function (string) {
   return string.charAt(0).toUpperCase() + string.substring(1)
 }
 
@@ -40,7 +41,7 @@ const capitalizeString = function(string) {
  * @param {string} timeString The string to check.
  * @return {boolean} Whether the string is a valid clock face time.
  */
-const isClockFaceTime = function(timeString) {
+const isClockFaceTime = function (timeString) {
   return (
     date.isValid(timeString, 'HH:mm') || date.isValid(timeString, 'HH:mm:ss')
   )
@@ -52,10 +53,20 @@ const isClockFaceTime = function(timeString) {
  * @param {string} dateTimeString The string to check.
  * @return {boolean} Whether the string is a valid date-time.
  */
-const isDateTime = function(dateTimeString) {
+const isDateTime = function (dateTimeString) {
   return (
     dateIsValid(parseISO(dateTimeString)) && rfc3339ish.test(dateTimeString)
   )
+}
+
+/**
+ * Determine if a string is a valid number.
+ *
+ * @param {string} numericString The string to check.
+ * @return {boolean} Whether the string is a valid number.
+ */
+const isNumber = function (numericString) {
+  return digitExpression.test(numericString)
 }
 
 module.exports = {
@@ -64,4 +75,5 @@ module.exports = {
   capitalizeString: capitalizeString,
   isClockFaceTime: isClockFaceTime,
   isDateTime: isDateTime,
+  isNumber: isNumber,
 }

--- a/validator/dataset.js
+++ b/validator/dataset.js
@@ -4,10 +4,10 @@ const { validateHedEvent } = require('./event')
  * Parse the dataset's definitions and evaluate labels in the dataset.
  *
  * @param {string[]} hedStrings The dataset's HED strings.
- * @param {Schema} hedSchema The HED schema.
+ * @param {Schemas} hedSchemas The HED schema container object.
  * @return {[Definitions, string[]]} The definitions and the evaluated HED strings.
  */
-const parseDefinitions = function(hedStrings, hedSchema) {
+const parseDefinitions = function(hedStrings, hedSchemas) {
   // TODO: Implement
   return [{}, hedStrings]
 }
@@ -17,10 +17,10 @@ const parseDefinitions = function(hedStrings, hedSchema) {
  *
  * @param {Definitions} definitions The parsed dataset definitions.
  * @param {string[]} hedStrings The dataset's HED strings.
- * @param {Schema} hedSchema The HED schema.
+ * @param {Schemas} hedSchemas The HED schema container object.
  * @return {[boolean, Issue[]]} Whether the HED dataset is valid and any issues found.
  */
-const validateDataset = function(definitions, hedStrings, hedSchema) {
+const validateDataset = function(definitions, hedStrings, hedSchemas) {
   // TODO: Implement
   return [true, []]
 }
@@ -29,17 +29,17 @@ const validateDataset = function(definitions, hedStrings, hedSchema) {
  * Validate a group of HED strings.
  *
  * @param {string[]} hedStrings A group of HED strings.
- * @param {Schema} hedSchema The HED schema.
+ * @param {Schemas} hedSchemas The HED schema container object.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @return {[boolean, Issue[]]} Whether the HED strings are valid and any issues found.
  */
-const validateHedEvents = function(hedStrings, hedSchema, checkForWarnings) {
+const validateHedEvents = function(hedStrings, hedSchemas, checkForWarnings) {
   let stringsValid = true
   let stringIssues = []
   for (const hedString of hedStrings) {
     const [valid, issues] = validateHedEvent(
       hedString,
-      hedSchema,
+      hedSchemas,
       checkForWarnings,
     )
     stringsValid = stringsValid && valid
@@ -52,26 +52,26 @@ const validateHedEvents = function(hedStrings, hedSchema, checkForWarnings) {
  * Validate a HED dataset.
  *
  * @param {string[]} hedStrings The dataset's HED strings.
- * @param {Schema} hedSchema The HED schema.
+ * @param {Schemas} hedSchemas The HED schema container object.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @return {[boolean, Issue[]]} Whether the HED dataset is valid and any issues found.
  */
 const validateHedDataset = function(
   hedStrings,
-  hedSchema,
+  hedSchemas,
   checkForWarnings = false,
 ) {
   const [stringsValid, stringIssues] = validateHedEvents(
     hedStrings,
-    hedSchema,
+    hedSchemas,
     checkForWarnings,
   )
   if (!stringsValid) {
     return [false, stringIssues]
   }
 
-  const [definitions, newHedStrings] = parseDefinitions(hedStrings, hedSchema)
-  return validateDataset(definitions, newHedStrings, hedSchema)
+  const [definitions, newHedStrings] = parseDefinitions(hedStrings, hedSchemas)
+  return validateDataset(definitions, newHedStrings, hedSchemas)
 }
 
 module.exports = {

--- a/validator/event.js
+++ b/validator/event.js
@@ -3,6 +3,7 @@ const {
   parseHedString,
   ParsedHedString,
   ParsedHedTag,
+  hedStringIsAGroup,
 } = require('./stringParser')
 const { buildSchemaAttributesObject } = require('./schema')
 const { Schemas } = require('../utils/schema')
@@ -508,6 +509,63 @@ const checkPlaceholderSyntax = function (tag) {
   }
 }
 
+// HED 3 checks
+
+/**
+ * Check the syntax of HED 3 definitions.
+ *
+ * @param {ParsedHedTag[]} tagGroup The tag group.
+ * @param {Schemas} hedSchemas The HED schema container.
+ * @return {[]} Any issues found.
+ */
+const checkDefinitionSyntax = function (tagGroup, hedSchemas) {
+  const definitionParentTag = 'attribute/informational/definition/'
+  const issues = []
+  let definitionTagFound = false
+  let definitionName
+  for (const tag of tagGroup) {
+    if (tag.formattedTag.startsWith(definitionParentTag)) {
+      definitionTagFound = true
+      definitionName = utils.HED.getTagName(tag.originalTag)
+      break
+    }
+  }
+  if (!definitionTagFound) {
+    return []
+  }
+  let tagGroupValidated = false
+  let tagGroupIssueGenerated = false
+  for (const tag of tagGroup) {
+    if (hedStringIsAGroup(tag.formattedTag)) {
+      if (tagGroupValidated && !tagGroupIssueGenerated) {
+        issues.push(
+          utils.issues.generateIssue('multipleTagGroupsInDefinition', {
+            definition: definitionName,
+          }),
+        )
+        tagGroupIssueGenerated = true
+        continue
+      }
+      tagGroupValidated = true
+      if (tag.formattedTag.indexOf(definitionParentTag) >= 0) {
+        issues.push(
+          utils.issues.generateIssue('nestedDefinition', {
+            definition: definitionName,
+          }),
+        )
+      }
+    } else if (!tag.formattedTag.startsWith(definitionParentTag)) {
+      issues.push(
+        utils.issues.generateIssue('illegalDefinitionGroupTag', {
+          tag: tag.originalTag,
+          definition: definitionName,
+        }),
+      )
+    }
+  }
+  return issues
+}
+
 // Validation groups
 
 /**
@@ -603,6 +661,9 @@ const validateHedTagLevel = function (
   let issues = []
   if (doSemanticValidation) {
     issues = issues.concat(checkForMultipleUniqueTags(tagList, hedSchemas))
+    if (hedSchemas.isHed3) {
+      issues = issues.concat(checkDefinitionSyntax(tagList, hedSchemas))
+    }
   }
   issues = issues.concat(checkForDuplicateTags(tagList))
   return issues
@@ -619,7 +680,7 @@ const validateHedTagLevels = function (
   let issues = []
   for (let i = 0; i < parsedString.tagGroups.length; i++) {
     const tagList = parsedString.tagGroups[i]
-    issues = issues.concat(validateHedTagLevel(tagList, hedSchemas))
+    issues = issues.concat(validateHedTagLevel(tagList, hedSchemas, doSemanticValidation))
   }
   issues = issues.concat(
     validateHedTagLevel(

--- a/validator/event.js
+++ b/validator/event.js
@@ -7,6 +7,7 @@ const {
 } = require('./stringParser')
 const { buildSchemaAttributesObject } = require('./schema')
 const { Schemas } = require('../utils/schema')
+const { convertHedStringToLong } = require('../converter/converter')
 
 const openingGroupCharacter = '('
 const closingGroupCharacter = ')'
@@ -265,14 +266,13 @@ const checkIfTagRequiresChild = function (tag, hedSchemas) {
 /**
  * Check that all required tags are present.
  */
-const checkForRequiredTags = function (parsedString, hedSchemas) {
+const checkForRequiredTags = function (topLevelTags, hedSchemas) {
   const issues = []
-  const topLevelTagList = parsedString.topLevelTags
   const requiredTagPrefixes =
     hedSchemas.baseSchema.attributes.dictionaries[requiredType]
   for (const requiredTagPrefix in requiredTagPrefixes) {
     let foundOne = false
-    for (const tag of topLevelTagList) {
+    for (const tag of topLevelTags) {
       if (tag.formattedTag.startsWith(requiredTagPrefix)) {
         foundOne = true
         break
@@ -416,10 +416,7 @@ const checkIfTagIsValid = function (
       tag.formattedTag,
       hedSchemas.baseSchema.attributes,
     ) || // This tag itself exists in the HED schema.
-    utils.HED.tagTakesValue(
-      tag.formattedTag,
-      hedSchemas.baseSchema.attributes,
-    ) // This tag is a valid value-taking tag in the HED schema.
+    utils.HED.tagTakesValue(tag.formattedTag, hedSchemas.baseSchema.attributes) // This tag is a valid value-taking tag in the HED schema.
   ) {
     return []
   }
@@ -515,22 +512,37 @@ const checkPlaceholderSyntax = function (tag) {
  * Check the syntax of HED 3 definitions.
  *
  * @param {ParsedHedTag[]} tagGroup The tag group.
- * @param {Schemas} hedSchemas The HED schema container.
- * @return {[]} Any issues found.
+ * @param {Schemas} hedSchemas The HED schema collection.
+ * @return {Issue[]} Any issues found.
  */
 const checkDefinitionSyntax = function (tagGroup, hedSchemas) {
-  const definitionParentTag = 'attribute/informational/definition/'
-  const issues = []
+  const definitionShortTag = 'definition'
+  const defExpandShortTag = 'def-expand'
+  const defShortTag = 'def'
+  const [
+    definitionParentTag,
+    definitionParentTagIssues,
+  ] = convertHedStringToLong(hedSchemas, definitionShortTag)
+  const [defExpandParentTag, defExpandParentTagIssues] = convertHedStringToLong(
+    hedSchemas,
+    defExpandShortTag,
+  )
+  const issues = [].concat(definitionParentTagIssues, defExpandParentTagIssues)
   let definitionTagFound = false
+  let defExpandTagFound = false
   let definitionName
   for (const tag of tagGroup) {
-    if (tag.formattedTag.startsWith(definitionParentTag)) {
+    if (tag.canonicalTag.startsWith(definitionParentTag)) {
       definitionTagFound = true
+      definitionName = utils.HED.getTagName(tag.originalTag)
+      break
+    } else if (tag.canonicalTag.startsWith(defExpandParentTag)) {
+      defExpandTagFound = true
       definitionName = utils.HED.getTagName(tag.originalTag)
       break
     }
   }
-  if (!definitionTagFound) {
+  if (!(definitionTagFound || defExpandTagFound)) {
     return []
   }
   let tagGroupValidated = false
@@ -547,20 +559,65 @@ const checkDefinitionSyntax = function (tagGroup, hedSchemas) {
         continue
       }
       tagGroupValidated = true
-      if (tag.formattedTag.indexOf(definitionParentTag) >= 0) {
+      if (
+        tag.formattedTag.indexOf(definitionShortTag) >= 0 ||
+        tag.formattedTag.indexOf(defExpandShortTag) >= 0
+      ) {
+        issues.push(
+          utils.issues.generateIssue('nestedDefinition', {
+            definition: definitionName,
+          }),
+        )
+      } else if (tag.formattedTag.indexOf(defShortTag) >= 0) {
         issues.push(
           utils.issues.generateIssue('nestedDefinition', {
             definition: definitionName,
           }),
         )
       }
-    } else if (!tag.formattedTag.startsWith(definitionParentTag)) {
+    } else if (
+      (definitionTagFound &&
+        !tag.canonicalTag.startsWith(definitionParentTag)) ||
+      (defExpandTagFound && !tag.canonicalTag.startsWith(defExpandParentTag))
+    ) {
       issues.push(
         utils.issues.generateIssue('illegalDefinitionGroupTag', {
           tag: tag.originalTag,
           definition: definitionName,
         }),
       )
+    }
+  }
+  return issues
+}
+
+/**
+ * Check for invalid top-level definition tags.
+ *
+ * @param {ParsedHedTag[]} topLevelTags The list of top-level tags.
+ * @param {Schemas} hedSchemas The HED schema collection.
+ * @return {Issue[]} Any issues found.
+ */
+const checkForInvalidTopLevelDefinitionTags = function (
+  topLevelTags,
+  hedSchemas,
+) {
+  let issues = []
+  const invalidShortTags = ['Definition', 'Def-expand']
+  for (const invalidShortTag of invalidShortTags) {
+    const [invalidTag, invalidTagIssues] = convertHedStringToLong(
+      hedSchemas,
+      invalidShortTag,
+    )
+    issues = issues.concat(invalidTagIssues)
+    for (const topLevelTag of topLevelTags) {
+      if (topLevelTag.canonicalTag.startsWith(invalidTag)) {
+        issues.push(
+          utils.issues.generateIssue('topLevelDefinitionTag', {
+            tag: topLevelTag.originalTag,
+          }),
+        )
+      }
     }
   }
   return issues
@@ -680,7 +737,9 @@ const validateHedTagLevels = function (
   let issues = []
   for (let i = 0; i < parsedString.tagGroups.length; i++) {
     const tagList = parsedString.tagGroups[i]
-    issues = issues.concat(validateHedTagLevel(tagList, hedSchemas, doSemanticValidation))
+    issues = issues.concat(
+      validateHedTagLevel(tagList, hedSchemas, doSemanticValidation),
+    )
   }
   issues = issues.concat(
     validateHedTagLevel(
@@ -721,11 +780,18 @@ const validateTopLevelTags = function (
   doSemanticValidation,
   checkForWarnings,
 ) {
-  if (doSemanticValidation && checkForWarnings) {
-    return checkForRequiredTags(parsedString, hedSchemas)
-  } else {
-    return []
+  let issues = []
+  const topLevelTags = parsedString.topLevelTags
+  if (hedSchemas.isHed3) {
+    // This is false when doSemanticValidation is false (i.e. there is no loaded schema).
+    issues = issues.concat(
+      checkForInvalidTopLevelDefinitionTags(topLevelTags, hedSchemas),
+    )
   }
+  if (doSemanticValidation && checkForWarnings) {
+    issues = issues.concat(checkForRequiredTags(topLevelTags, hedSchemas))
+  }
+  return issues
 }
 
 /**

--- a/validator/event.js
+++ b/validator/event.js
@@ -6,8 +6,7 @@ const { Schemas } = require('../utils/schema')
 const openingGroupCharacter = '('
 const closingGroupCharacter = ')'
 const comma = ','
-const tilde = '~'
-const delimiters = [comma, tilde]
+const delimiters = [comma]
 
 const uniqueType = 'unique'
 const requiredType = 'required'
@@ -188,7 +187,6 @@ const checkForDuplicateTags = function (tagList) {
         continue
       }
       if (
-        tagList[i].formattedTag !== tilde &&
         tagList[i].formattedTag === tagList[j].formattedTag &&
         !duplicateIndices.includes(i) &&
         !duplicateIndices.includes(j)
@@ -241,28 +239,6 @@ const checkForMultipleUniqueTags = function (tagList, hedSchemas) {
     }
   }
   return issues
-}
-
-/**
- * Verify that the tilde count in a single group does not exceed 2.
- */
-const checkNumberOfGroupTildes = function (originalTagGroup, parsedTagGroup) {
-  const issues = []
-  const tildeCount = utils.array.getElementCount(
-    parsedTagGroup.map((group) => {
-      return group.originalTag
-    }),
-    tilde,
-  )
-  if (tildeCount > 2) {
-    issues.push(
-      utils.issues.generateIssue('tooManyTildes', {
-        tagGroup: originalTagGroup.originalTag,
-      }),
-    )
-    return issues
-  }
-  return []
 }
 
 /**
@@ -438,8 +414,7 @@ const checkIfTagIsValid = function (
     utils.HED.tagTakesValue(
       tag.formattedTag,
       hedSchemas.baseSchema.attributes,
-    ) || // This tag is a valid value-taking tag in the HED schema.
-    tag.formattedTag === tilde // This "tag" is a tilde.
+    ) // This tag is a valid value-taking tag in the HED schema.
   ) {
     return []
   }
@@ -620,7 +595,7 @@ const validateHedTagLevels = function (
  * Validate a HED tag group.
  */
 const validateHedTagGroup = function (originalTagGroup, parsedTagGroup) {
-  return checkNumberOfGroupTildes(originalTagGroup, parsedTagGroup)
+  return []
 }
 
 /**

--- a/validator/event.js
+++ b/validator/event.js
@@ -1,6 +1,5 @@
 const utils = require('../utils')
-const { parseHedString } = require('./stringParser')
-const { convertHedStringToLong } = require('../converter/converter')
+const { parseHedString, ParsedHedTag } = require('./stringParser')
 const { buildSchemaAttributesObject } = require('./schema')
 const { Schemas } = require('../utils/schema')
 
@@ -23,11 +22,11 @@ const timeUnitClass = 'time'
 /**
  * Substitute certain illegal characters and report warnings when found.
  */
-const substituteCharacters = function(hedString) {
+const substituteCharacters = function (hedString) {
   const issues = []
   const illegalCharacterMap = { '\0': ['ASCII NUL', ' '] }
   const flaggedCharacters = /[^\w\d./$ :-]/g
-  const replaceFunction = function(match, offset) {
+  const replaceFunction = function (match, offset) {
     if (match in illegalCharacterMap) {
       const [name, replacement] = illegalCharacterMap[match]
       issues.push(
@@ -50,7 +49,7 @@ const substituteCharacters = function(hedString) {
 /**
  * Check if group parentheses match. Pushes an issue if they don't match.
  */
-const countTagGroupParentheses = function(hedString) {
+const countTagGroupParentheses = function (hedString) {
   const issues = []
   const numberOfOpeningParentheses = utils.string.getCharacterCount(
     hedString,
@@ -74,7 +73,7 @@ const countTagGroupParentheses = function(hedString) {
 /**
  * Check if a comma is missing after an opening parenthesis.
  */
-const isCommaMissingAfterClosingParenthesis = function(
+const isCommaMissingAfterClosingParenthesis = function (
   lastNonEmptyCharacter,
   currentCharacter,
 ) {
@@ -90,7 +89,7 @@ const isCommaMissingAfterClosingParenthesis = function(
 /**
  * Check for delimiter issues in a HED string (e.g. missing commas adjacent to groups, extra commas or tildes).
  */
-const findDelimiterIssuesInHedString = function(hedString) {
+const findDelimiterIssuesInHedString = function (hedString) {
   const issues = []
   let lastNonEmptyValidCharacter = ''
   let lastNonEmptyValidIndex = 0
@@ -118,7 +117,9 @@ const findDelimiterIssuesInHedString = function(hedString) {
       if (currentTag.trim() === openingGroupCharacter) {
         currentTag = ''
       } else {
-        issues.push(utils.issues.generateIssue('invalidTag', { tag: currentTag }))
+        issues.push(
+          utils.issues.generateIssue('invalidTag', { tag: currentTag }),
+        )
       }
     } else if (
       isCommaMissingAfterClosingParenthesis(
@@ -153,24 +154,21 @@ const camelCase = /([A-Z-]+\s*[a-z-]*)+/
 /**
  * Check if tag level capitalization is valid (CamelCase).
  */
-const checkCapitalization = function(
-  originalTag,
-  formattedTag,
-  hedSchemas,
-  doSemanticValidation,
-) {
+const checkCapitalization = function (tag, hedSchemas, doSemanticValidation) {
   const issues = []
-  const tagNames = originalTag.split('/')
+  const tagNames = tag.originalTag.split('/')
   if (
     doSemanticValidation &&
-    utils.HED.tagTakesValue(formattedTag, hedSchemas.baseSchema.attributes)
+    utils.HED.tagTakesValue(tag.formattedTag, hedSchemas.baseSchema.attributes)
   ) {
     tagNames.pop()
   }
   for (const tagName of tagNames) {
     const correctTagName = utils.string.capitalizeString(tagName)
     if (tagName !== correctTagName && !camelCase.test(tagName)) {
-      issues.push(utils.issues.generateIssue('capitalization', { tag: originalTag }))
+      issues.push(
+        utils.issues.generateIssue('capitalization', { tag: tag.originalTag }),
+      )
     }
   }
   return issues
@@ -180,9 +178,9 @@ const checkCapitalization = function(
  * Check for duplicate tags at the top level or within a single group.
  * NOTE: Nested groups are treated as single tags for this validation.
  */
-const checkForDuplicateTags = function(originalTagList, formattedTagList) {
+const checkForDuplicateTags = function (tagList) {
   const issues = []
-  const tagListLength = formattedTagList.length
+  const tagListLength = tagList.length
   const duplicateIndices = []
   for (let i = 0; i < tagListLength; i++) {
     for (let j = 0; j < tagListLength; j++) {
@@ -190,15 +188,28 @@ const checkForDuplicateTags = function(originalTagList, formattedTagList) {
         continue
       }
       if (
-        formattedTagList[i] !== tilde &&
-        formattedTagList[i] === formattedTagList[j] &&
+        tagList[i].formattedTag !== tilde &&
+        tagList[i].formattedTag === tagList[j].formattedTag &&
         !duplicateIndices.includes(i) &&
         !duplicateIndices.includes(j)
       ) {
         duplicateIndices.push(i, j)
-        issues.push(
-          utils.issues.generateIssue('duplicateTag', { tag: originalTagList[i] }),
-        )
+        if (
+          tagList[i].originalTag.toLowerCase() ===
+          tagList[j].originalTag.toLowerCase()
+        ) {
+          issues.push(
+            utils.issues.generateIssue('duplicateTag', {
+              tag: tagList[i].originalTag,
+            }),
+          )
+        } else {
+          issues.push(
+            utils.issues.generateIssue('duplicateTag', {
+              tag: tagList[i].canonicalTag,
+            }),
+          )
+        }
       }
     }
   }
@@ -208,18 +219,14 @@ const checkForDuplicateTags = function(originalTagList, formattedTagList) {
 /**
  * Check for multiple instances of a unique tag.
  */
-const checkForMultipleUniqueTags = function(
-  originalTagList,
-  formattedTagList,
-  hedSchemas,
-) {
+const checkForMultipleUniqueTags = function (tagList, hedSchemas) {
   const issues = []
   const uniqueTagPrefixes =
     hedSchemas.baseSchema.attributes.dictionaries[uniqueType]
   for (const uniqueTagPrefix in uniqueTagPrefixes) {
     let foundOne = false
-    for (const formattedTag of formattedTagList) {
-      if (formattedTag.startsWith(uniqueTagPrefix)) {
+    for (const tag of tagList) {
+      if (tag.formattedTag.startsWith(uniqueTagPrefix)) {
         if (!foundOne) {
           foundOne = true
         } else {
@@ -239,12 +246,19 @@ const checkForMultipleUniqueTags = function(
 /**
  * Verify that the tilde count in a single group does not exceed 2.
  */
-const checkNumberOfGroupTildes = function(originalTagGroup, parsedTagGroup) {
+const checkNumberOfGroupTildes = function (originalTagGroup, parsedTagGroup) {
   const issues = []
-  const tildeCount = utils.array.getElementCount(parsedTagGroup, tilde)
+  const tildeCount = utils.array.getElementCount(
+    parsedTagGroup.map((group) => {
+      return group.originalTag
+    }),
+    tilde,
+  )
   if (tildeCount > 2) {
     issues.push(
-      utils.issues.generateIssue('tooManyTildes', { tagGroup: originalTagGroup }),
+      utils.issues.generateIssue('tooManyTildes', {
+        tagGroup: originalTagGroup.originalTag,
+      }),
     )
     return issues
   }
@@ -254,17 +268,15 @@ const checkNumberOfGroupTildes = function(originalTagGroup, parsedTagGroup) {
 /**
  * Check if a tag is missing a required child.
  */
-const checkIfTagRequiresChild = function(
-  originalTag,
-  formattedTag,
-  hedSchemas,
-) {
+const checkIfTagRequiresChild = function (tag, hedSchemas) {
   const issues = []
   const invalid =
-    formattedTag in
+    tag.formattedTag in
     hedSchemas.baseSchema.attributes.dictionaries[requireChildType]
   if (invalid) {
-    issues.push(utils.issues.generateIssue('childRequired', { tag: originalTag }))
+    issues.push(
+      utils.issues.generateIssue('childRequired', { tag: tag.originalTag }),
+    )
   }
   return issues
 }
@@ -272,15 +284,15 @@ const checkIfTagRequiresChild = function(
 /**
  * Check that all required tags are present.
  */
-const checkForRequiredTags = function(parsedString, hedSchemas) {
+const checkForRequiredTags = function (parsedString, hedSchemas) {
   const issues = []
-  const formattedTopLevelTagList = parsedString.formattedTopLevelTags
+  const topLevelTagList = parsedString.topLevelTags
   const requiredTagPrefixes =
     hedSchemas.baseSchema.attributes.dictionaries[requiredType]
   for (const requiredTagPrefix in requiredTagPrefixes) {
     let foundOne = false
-    for (const formattedTag of formattedTopLevelTagList) {
-      if (formattedTag.startsWith(requiredTagPrefix)) {
+    for (const tag of topLevelTagList) {
+      if (tag.formattedTag.startsWith(requiredTagPrefix)) {
         foundOne = true
         break
       }
@@ -299,26 +311,25 @@ const checkForRequiredTags = function(parsedString, hedSchemas) {
 /**
  * Check that the unit exists if the tag has a declared unit class.
  */
-const checkIfTagUnitClassUnitsExist = function(
-  originalTag,
-  formattedTag,
+const checkIfTagUnitClassUnitsExist = function (
+  tag,
   hedSchemas,
   allowPlaceholders = false,
 ) {
   const issues = []
   if (
-    utils.HED.isUnitClassTag(formattedTag, hedSchemas.baseSchema.attributes)
+    utils.HED.isUnitClassTag(tag.formattedTag, hedSchemas.baseSchema.attributes)
   ) {
-    const tagUnitValues = utils.HED.getTagName(formattedTag)
+    const tagUnitValues = utils.HED.getTagName(tag.formattedTag)
     const invalid = utils.HED.validateValue(tagUnitValues, allowPlaceholders)
     if (invalid) {
       const defaultUnit = utils.HED.getUnitClassDefaultUnit(
-        formattedTag,
+        tag.formattedTag,
         hedSchemas.baseSchema.attributes,
       )
       issues.push(
         utils.issues.generateIssue('unitClassDefaultUsed', {
-          tag: originalTag,
+          tag: tag.originalTag,
           defaultUnit: defaultUnit,
         }),
       )
@@ -332,28 +343,27 @@ const checkIfTagUnitClassUnitsExist = function(
 /**
  * Check that the unit is valid for the tag's unit class.
  */
-const checkIfTagUnitClassUnitsAreValid = function(
-  originalTag,
-  formattedTag,
+const checkIfTagUnitClassUnitsAreValid = function (
+  tag,
   hedSchemas,
   allowPlaceholders = false,
 ) {
   const issues = []
   if (
     !utils.HED.tagExistsInSchema(
-      formattedTag,
+      tag.formattedTag,
       hedSchemas.baseSchema.attributes,
     ) &&
-    utils.HED.isUnitClassTag(formattedTag, hedSchemas.baseSchema.attributes)
+    utils.HED.isUnitClassTag(tag.formattedTag, hedSchemas.baseSchema.attributes)
   ) {
     const tagUnitClasses = utils.HED.getTagUnitClasses(
-      formattedTag,
+      tag.formattedTag,
       hedSchemas.baseSchema.attributes,
     )
-    const originalTagUnitValue = utils.HED.getTagName(originalTag)
-    const formattedTagUnitValue = utils.HED.getTagName(formattedTag)
+    const originalTagUnitValue = utils.HED.getTagName(tag.originalTag)
+    const formattedTagUnitValue = utils.HED.getTagName(tag.formattedTag)
     const tagUnitClassUnits = utils.HED.getTagUnitClassUnits(
-      formattedTag,
+      tag.formattedTag,
       hedSchemas.baseSchema.attributes,
     )
     if (
@@ -398,7 +408,7 @@ const checkIfTagUnitClassUnitsAreValid = function(
     if (!validUnit) {
       issues.push(
         utils.issues.generateIssue('unitClassInvalidUnit', {
-          tag: originalTag,
+          tag: tag.originalTag,
           unitClassUnits: tagUnitClassUnits.sort().join(','),
         }),
       )
@@ -412,11 +422,9 @@ const checkIfTagUnitClassUnitsAreValid = function(
 /**
  * Check if an individual HED tag is in the schema or is an allowed extension.
  */
-const checkIfTagIsValid = function(
-  originalTag,
-  formattedTag,
-  previousOriginalTag,
-  previousFormattedTag,
+const checkIfTagIsValid = function (
+  tag,
+  previousTag,
   hedSchemas,
   allowPlaceholders,
   checkForWarnings,
@@ -424,26 +432,31 @@ const checkIfTagIsValid = function(
   const issues = []
   if (
     utils.HED.tagExistsInSchema(
-      formattedTag,
+      tag.formattedTag,
       hedSchemas.baseSchema.attributes,
     ) || // This tag itself exists in the HED schema.
-    utils.HED.tagTakesValue(formattedTag, hedSchemas.baseSchema.attributes) || // This tag is a valid value-taking tag in the HED schema.
-    formattedTag === tilde // This "tag" is a tilde.
+    utils.HED.tagTakesValue(
+      tag.formattedTag,
+      hedSchemas.baseSchema.attributes,
+    ) || // This tag is a valid value-taking tag in the HED schema.
+    tag.formattedTag === tilde // This "tag" is a tilde.
   ) {
     return []
   }
   // Whether this tag has an ancestor with the 'extensionAllowed' attribute.
   const isExtensionAllowedTag = utils.HED.isExtensionAllowedTag(
-    formattedTag,
+    tag.formattedTag,
     hedSchemas.baseSchema.attributes,
   )
-  if (allowPlaceholders && formattedTag.split('#').length === 2) {
-    const valueTag = utils.HED.replaceTagNameWithPound(formattedTag)
+  if (allowPlaceholders && tag.formattedTag.split('#').length === 2) {
+    const valueTag = utils.HED.replaceTagNameWithPound(tag.formattedTag)
     if (utils.HED.tagTakesValue(valueTag, hedSchemas.baseSchema.attributes)) {
       return []
     } else {
       issues.push(
-        utils.issues.generateIssue('invalidPlaceholder', { tag: originalTag }),
+        utils.issues.generateIssue('invalidPlaceholder', {
+          tag: tag.originalTag,
+        }),
       )
       return issues
     }
@@ -451,7 +464,7 @@ const checkIfTagIsValid = function(
   if (
     !isExtensionAllowedTag &&
     utils.HED.tagTakesValue(
-      previousFormattedTag,
+      previousTag.formattedTag,
       hedSchemas.baseSchema.attributes,
     )
   ) {
@@ -459,19 +472,23 @@ const checkIfTagIsValid = function(
     // This is likely caused by an extraneous comma.
     issues.push(
       utils.issues.generateIssue('extraCommaOrInvalid', {
-        tag: originalTag,
-        previousTag: previousOriginalTag,
+        tag: tag.originalTag,
+        previousTag: previousTag.originalTag,
       }),
     )
     return issues
   } else if (!isExtensionAllowedTag) {
     // This is not a valid tag.
-    issues.push(utils.issues.generateIssue('invalidTag', { tag: originalTag }))
+    issues.push(
+      utils.issues.generateIssue('invalidTag', { tag: tag.originalTag }),
+    )
     return issues
   } else {
     // This is an allowed extension.
     if (checkForWarnings) {
-      issues.push(utils.issues.generateIssue('extension', { tag: originalTag }))
+      issues.push(
+        utils.issues.generateIssue('extension', { tag: tag.originalTag }),
+      )
       return issues
     } else {
       return []
@@ -484,7 +501,7 @@ const checkIfTagIsValid = function(
 /**
  * Validate the full HED string.
  */
-const validateFullHedString = function(hedString) {
+const validateFullHedString = function (hedString) {
   const [fixedHedString, substitutionIssues] = substituteCharacters(hedString)
   const issues = [].concat(
     countTagGroupParentheses(fixedHedString),
@@ -496,11 +513,9 @@ const validateFullHedString = function(hedString) {
 /**
  * Validate an individual HED tag.
  */
-const validateIndividualHedTag = function(
-  originalTag,
-  formattedTag,
-  previousOriginalTag,
-  previousFormattedTag,
+const validateIndividualHedTag = function (
+  tag,
+  previousTag,
   hedSchemas,
   doSemanticValidation,
   checkForWarnings,
@@ -510,41 +525,24 @@ const validateIndividualHedTag = function(
   if (doSemanticValidation) {
     issues = issues.concat(
       checkIfTagIsValid(
-        originalTag,
-        formattedTag,
-        previousOriginalTag,
-        previousFormattedTag,
+        tag,
+        previousTag,
         hedSchemas,
         allowPlaceholders,
         checkForWarnings,
       ),
-      checkIfTagUnitClassUnitsAreValid(
-        originalTag,
-        formattedTag,
-        hedSchemas,
-        allowPlaceholders,
-      ),
-      checkIfTagRequiresChild(originalTag, formattedTag, hedSchemas),
+      checkIfTagUnitClassUnitsAreValid(tag, hedSchemas, allowPlaceholders),
+      checkIfTagRequiresChild(tag, hedSchemas),
     )
     if (checkForWarnings) {
       issues = issues.concat(
-        checkIfTagUnitClassUnitsExist(
-          originalTag,
-          formattedTag,
-          hedSchemas,
-          allowPlaceholders,
-        ),
+        checkIfTagUnitClassUnitsExist(tag, hedSchemas, allowPlaceholders),
       )
     }
   }
   if (checkForWarnings) {
     issues = issues.concat(
-      checkCapitalization(
-        originalTag,
-        formattedTag,
-        hedSchemas,
-        doSemanticValidation,
-      ),
+      checkCapitalization(tag, hedSchemas, doSemanticValidation),
     )
   }
   return issues
@@ -553,7 +551,7 @@ const validateIndividualHedTag = function(
 /**
  * Validate the individual HED tags in a parsed HED string object.
  */
-const validateIndividualHedTags = function(
+const validateIndividualHedTags = function (
   parsedString,
   hedSchemas,
   doSemanticValidation,
@@ -561,25 +559,20 @@ const validateIndividualHedTags = function(
   allowPlaceholders = false,
 ) {
   let issues = []
-  let previousOriginalTag = ''
-  let previousFormattedTag = ''
+  let previousTag = new ParsedHedTag('', [0, 0], hedSchemas)
   for (let i = 0; i < parsedString.tags.length; i++) {
-    const originalTag = parsedString.tags[i]
-    const formattedTag = parsedString.formattedTags[i]
+    const tag = parsedString.tags[i]
     issues = issues.concat(
       validateIndividualHedTag(
-        originalTag,
-        formattedTag,
-        previousOriginalTag,
-        previousFormattedTag,
+        tag,
+        previousTag,
         hedSchemas,
         doSemanticValidation,
         checkForWarnings,
         allowPlaceholders,
       ),
     )
-    previousOriginalTag = originalTag
-    previousFormattedTag = formattedTag
+    previousTag = tag
   }
   return issues
 }
@@ -587,44 +580,35 @@ const validateIndividualHedTags = function(
 /**
  * Validate a HED tag level.
  */
-const validateHedTagLevel = function(
-  originalTagList,
-  formattedTagList,
+const validateHedTagLevel = function (
+  tagList,
   hedSchemas,
   doSemanticValidation,
 ) {
   let issues = []
   if (doSemanticValidation) {
-    issues = issues.concat(
-      checkForMultipleUniqueTags(originalTagList, formattedTagList, hedSchemas),
-    )
+    issues = issues.concat(checkForMultipleUniqueTags(tagList, hedSchemas))
   }
-  issues = issues.concat(
-    checkForDuplicateTags(originalTagList, formattedTagList),
-  )
+  issues = issues.concat(checkForDuplicateTags(tagList))
   return issues
 }
 
 /**
  * Validate the HED tag levels in a parsed HED string object.
  */
-const validateHedTagLevels = function(
+const validateHedTagLevels = function (
   parsedString,
   hedSchemas,
   doSemanticValidation,
 ) {
   let issues = []
   for (let i = 0; i < parsedString.tagGroups.length; i++) {
-    const originalTagList = parsedString.tagGroups[i]
-    const formattedTagList = parsedString.formattedTagGroups[i]
-    issues = issues.concat(
-      validateHedTagLevel(originalTagList, formattedTagList, hedSchemas),
-    )
+    const tagList = parsedString.tagGroups[i]
+    issues = issues.concat(validateHedTagLevel(tagList, hedSchemas))
   }
   issues = issues.concat(
     validateHedTagLevel(
       parsedString.topLevelTags,
-      parsedString.formattedTopLevelTags,
       hedSchemas,
       doSemanticValidation,
     ),
@@ -635,14 +619,14 @@ const validateHedTagLevels = function(
 /**
  * Validate a HED tag group.
  */
-const validateHedTagGroup = function(originalTagGroup, parsedTagGroup) {
+const validateHedTagGroup = function (originalTagGroup, parsedTagGroup) {
   return checkNumberOfGroupTildes(originalTagGroup, parsedTagGroup)
 }
 
 /**
  * Validate the HED tag groups in a parsed HED string.
  */
-const validateHedTagGroups = function(parsedString) {
+const validateHedTagGroups = function (parsedString) {
   let issues = []
   for (let i = 0; i < parsedString.tagGroups.length; i++) {
     const parsedTag = parsedString.tagGroups[i]
@@ -655,7 +639,7 @@ const validateHedTagGroups = function(parsedString) {
 /**
  * Validate the top-level HED tags in a parsed HED string.
  */
-const validateTopLevelTags = function(
+const validateTopLevelTags = function (
   parsedString,
   hedSchemas,
   doSemanticValidation,
@@ -676,7 +660,7 @@ const validateTopLevelTags = function(
  * @param {boolean} doSemanticValidation Whether to perform semantic validation.
  * @return {Array} Whether validation passed, any issues, and any parsed string data.
  */
-const initiallyValidateHedString = function(
+const initiallyValidateHedString = function (
   hedString,
   hedSchemas,
   doSemanticValidation,
@@ -687,16 +671,6 @@ const initiallyValidateHedString = function(
         hedSchemas.baseSchema.xmlData,
       )
     }
-    if (hedSchemas.baseSchema.mapping) {
-      let hedStringConversionIssues
-      ;[hedString, hedStringConversionIssues] = convertHedStringToLong(
-        hedSchemas,
-        hedString,
-      )
-      if (hedStringConversionIssues.length !== 0) {
-        return [false, hedStringConversionIssues, null]
-      }
-    }
   }
   const [substitutionIssues, fullHedStringIssues] = validateFullHedString(
     hedString,
@@ -705,7 +679,10 @@ const initiallyValidateHedString = function(
     return [false, fullHedStringIssues.concat(substitutionIssues), null]
   }
 
-  const [parsedString, parsedStringIssues] = parseHedString(hedString)
+  const [parsedString, parsedStringIssues] = parseHedString(
+    hedString,
+    hedSchemas,
+  )
   if (parsedStringIssues.length !== 0) {
     return [false, parsedStringIssues.concat(substitutionIssues), null]
   }
@@ -722,7 +699,7 @@ const initiallyValidateHedString = function(
  * @param {boolean} allowPlaceholders Whether to treat value-taking tags with '#' placeholders as valid.
  * @returns {[boolean, Issue[]]} Whether the HED string is valid and any issues found.
  */
-const validateHedString = function(
+const validateHedString = function (
   hedString,
   hedSchemas,
   checkForWarnings = false,
@@ -763,12 +740,15 @@ const validateHedString = function(
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @returns {[boolean, Issue[]]} Whether the HED string is valid and any issues found.
  */
-const validateHedEvent = function(
+const validateHedEvent = function (
   hedString,
   hedSchemas,
   checkForWarnings = false,
 ) {
   const doSemanticValidation = hedSchemas instanceof Schemas
+  if (!doSemanticValidation) {
+    hedSchemas = new Schemas(null)
+  }
   const [
     initiallyValid,
     initialIssues,

--- a/validator/event.js
+++ b/validator/event.js
@@ -2,7 +2,7 @@ const utils = require('../utils')
 const { parseHedString } = require('./stringParser')
 const { convertHedStringToLong } = require('../converter/converter')
 const { buildSchemaAttributesObject } = require('./schema')
-const { Schema } = require('../utils/schema')
+const { Schemas } = require('../utils/schema')
 
 const openingGroupCharacter = '('
 const closingGroupCharacter = ')'
@@ -156,14 +156,14 @@ const camelCase = /([A-Z-]+\s*[a-z-]*)+/
 const checkCapitalization = function(
   originalTag,
   formattedTag,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
 ) {
   const issues = []
   const tagNames = originalTag.split('/')
   if (
     doSemanticValidation &&
-    utils.HED.tagTakesValue(formattedTag, hedSchema.attributes)
+    utils.HED.tagTakesValue(formattedTag, hedSchemas.baseSchema.attributes)
   ) {
     tagNames.pop()
   }
@@ -211,10 +211,11 @@ const checkForDuplicateTags = function(originalTagList, formattedTagList) {
 const checkForMultipleUniqueTags = function(
   originalTagList,
   formattedTagList,
-  hedSchema,
+  hedSchemas,
 ) {
   const issues = []
-  const uniqueTagPrefixes = hedSchema.attributes.dictionaries[uniqueType]
+  const uniqueTagPrefixes =
+    hedSchemas.baseSchema.attributes.dictionaries[uniqueType]
   for (const uniqueTagPrefix in uniqueTagPrefixes) {
     let foundOne = false
     for (const formattedTag of formattedTagList) {
@@ -253,10 +254,15 @@ const checkNumberOfGroupTildes = function(originalTagGroup, parsedTagGroup) {
 /**
  * Check if a tag is missing a required child.
  */
-const checkIfTagRequiresChild = function(originalTag, formattedTag, hedSchema) {
+const checkIfTagRequiresChild = function(
+  originalTag,
+  formattedTag,
+  hedSchemas,
+) {
   const issues = []
   const invalid =
-    formattedTag in hedSchema.attributes.dictionaries[requireChildType]
+    formattedTag in
+    hedSchemas.baseSchema.attributes.dictionaries[requireChildType]
   if (invalid) {
     issues.push(utils.issues.generateIssue('childRequired', { tag: originalTag }))
   }
@@ -266,10 +272,11 @@ const checkIfTagRequiresChild = function(originalTag, formattedTag, hedSchema) {
 /**
  * Check that all required tags are present.
  */
-const checkForRequiredTags = function(parsedString, hedSchema) {
+const checkForRequiredTags = function(parsedString, hedSchemas) {
   const issues = []
   const formattedTopLevelTagList = parsedString.formattedTopLevelTags
-  const requiredTagPrefixes = hedSchema.attributes.dictionaries[requiredType]
+  const requiredTagPrefixes =
+    hedSchemas.baseSchema.attributes.dictionaries[requiredType]
   for (const requiredTagPrefix in requiredTagPrefixes) {
     let foundOne = false
     for (const formattedTag of formattedTopLevelTagList) {
@@ -295,17 +302,19 @@ const checkForRequiredTags = function(parsedString, hedSchema) {
 const checkIfTagUnitClassUnitsExist = function(
   originalTag,
   formattedTag,
-  hedSchema,
+  hedSchemas,
   allowPlaceholders = false,
 ) {
   const issues = []
-  if (utils.HED.isUnitClassTag(formattedTag, hedSchema.attributes)) {
+  if (
+    utils.HED.isUnitClassTag(formattedTag, hedSchemas.baseSchema.attributes)
+  ) {
     const tagUnitValues = utils.HED.getTagName(formattedTag)
     const invalid = utils.HED.validateValue(tagUnitValues, allowPlaceholders)
     if (invalid) {
       const defaultUnit = utils.HED.getUnitClassDefaultUnit(
         formattedTag,
-        hedSchema.attributes,
+        hedSchemas.baseSchema.attributes,
       )
       issues.push(
         utils.issues.generateIssue('unitClassDefaultUsed', {
@@ -326,25 +335,31 @@ const checkIfTagUnitClassUnitsExist = function(
 const checkIfTagUnitClassUnitsAreValid = function(
   originalTag,
   formattedTag,
-  hedSchema,
+  hedSchemas,
   allowPlaceholders = false,
 ) {
   const issues = []
   if (
-    !utils.HED.tagExistsInSchema(formattedTag, hedSchema.attributes) &&
-    utils.HED.isUnitClassTag(formattedTag, hedSchema.attributes)
+    !utils.HED.tagExistsInSchema(
+      formattedTag,
+      hedSchemas.baseSchema.attributes,
+    ) &&
+    utils.HED.isUnitClassTag(formattedTag, hedSchemas.baseSchema.attributes)
   ) {
     const tagUnitClasses = utils.HED.getTagUnitClasses(
       formattedTag,
-      hedSchema.attributes,
+      hedSchemas.baseSchema.attributes,
     )
     const originalTagUnitValue = utils.HED.getTagName(originalTag)
     const formattedTagUnitValue = utils.HED.getTagName(formattedTag)
     const tagUnitClassUnits = utils.HED.getTagUnitClassUnits(
       formattedTag,
-      hedSchema.attributes,
+      hedSchemas.baseSchema.attributes,
     )
-    if (dateTimeUnitClass in hedSchema.attributes.dictionaries[unitsElement]) {
+    if (
+      dateTimeUnitClass in
+      hedSchemas.baseSchema.attributes.dictionaries[unitsElement]
+    ) {
       if (
         tagUnitClasses.includes(dateTimeUnitClass) &&
         utils.string.isDateTime(formattedTagUnitValue)
@@ -352,7 +367,10 @@ const checkIfTagUnitClassUnitsAreValid = function(
         return []
       }
     }
-    if (clockTimeUnitClass in hedSchema.attributes.dictionaries[unitsElement]) {
+    if (
+      clockTimeUnitClass in
+      hedSchemas.baseSchema.attributes.dictionaries[unitsElement]
+    ) {
       if (
         tagUnitClasses.includes(clockTimeUnitClass) &&
         utils.string.isClockFaceTime(formattedTagUnitValue)
@@ -360,7 +378,8 @@ const checkIfTagUnitClassUnitsAreValid = function(
         return []
       }
     } else if (
-      timeUnitClass in hedSchema.attributes.dictionaries[unitsElement]
+      timeUnitClass in
+      hedSchemas.baseSchema.attributes.dictionaries[unitsElement]
     ) {
       if (
         tagUnitClasses.includes(timeUnitClass) &&
@@ -373,7 +392,7 @@ const checkIfTagUnitClassUnitsAreValid = function(
       originalTagUnitValue,
       formattedTagUnitValue,
       tagUnitClassUnits,
-      hedSchema.attributes,
+      hedSchemas.baseSchema.attributes,
     )
     const validUnit = utils.HED.validateValue(value, allowPlaceholders)
     if (!validUnit) {
@@ -398,14 +417,17 @@ const checkIfTagIsValid = function(
   formattedTag,
   previousOriginalTag,
   previousFormattedTag,
-  hedSchema,
+  hedSchemas,
   allowPlaceholders,
   checkForWarnings,
 ) {
   const issues = []
   if (
-    utils.HED.tagExistsInSchema(formattedTag, hedSchema.attributes) || // This tag itself exists in the HED schema.
-    utils.HED.tagTakesValue(formattedTag, hedSchema.attributes) || // This tag is a valid value-taking tag in the HED schema.
+    utils.HED.tagExistsInSchema(
+      formattedTag,
+      hedSchemas.baseSchema.attributes,
+    ) || // This tag itself exists in the HED schema.
+    utils.HED.tagTakesValue(formattedTag, hedSchemas.baseSchema.attributes) || // This tag is a valid value-taking tag in the HED schema.
     formattedTag === tilde // This "tag" is a tilde.
   ) {
     return []
@@ -413,11 +435,11 @@ const checkIfTagIsValid = function(
   // Whether this tag has an ancestor with the 'extensionAllowed' attribute.
   const isExtensionAllowedTag = utils.HED.isExtensionAllowedTag(
     formattedTag,
-    hedSchema.attributes,
+    hedSchemas.baseSchema.attributes,
   )
   if (allowPlaceholders && formattedTag.split('#').length === 2) {
     const valueTag = utils.HED.replaceTagNameWithPound(formattedTag)
-    if (utils.HED.tagTakesValue(valueTag, hedSchema.attributes)) {
+    if (utils.HED.tagTakesValue(valueTag, hedSchemas.baseSchema.attributes)) {
       return []
     } else {
       issues.push(
@@ -428,7 +450,10 @@ const checkIfTagIsValid = function(
   }
   if (
     !isExtensionAllowedTag &&
-    utils.HED.tagTakesValue(previousFormattedTag, hedSchema.attributes)
+    utils.HED.tagTakesValue(
+      previousFormattedTag,
+      hedSchemas.baseSchema.attributes,
+    )
   ) {
     // This tag isn't an allowed extension, but the previous tag takes a value.
     // This is likely caused by an extraneous comma.
@@ -476,7 +501,7 @@ const validateIndividualHedTag = function(
   formattedTag,
   previousOriginalTag,
   previousFormattedTag,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
   checkForWarnings,
   allowPlaceholders,
@@ -489,24 +514,24 @@ const validateIndividualHedTag = function(
         formattedTag,
         previousOriginalTag,
         previousFormattedTag,
-        hedSchema,
+        hedSchemas,
         allowPlaceholders,
         checkForWarnings,
       ),
       checkIfTagUnitClassUnitsAreValid(
         originalTag,
         formattedTag,
-        hedSchema,
+        hedSchemas,
         allowPlaceholders,
       ),
-      checkIfTagRequiresChild(originalTag, formattedTag, hedSchema),
+      checkIfTagRequiresChild(originalTag, formattedTag, hedSchemas),
     )
     if (checkForWarnings) {
       issues = issues.concat(
         checkIfTagUnitClassUnitsExist(
           originalTag,
           formattedTag,
-          hedSchema,
+          hedSchemas,
           allowPlaceholders,
         ),
       )
@@ -517,7 +542,7 @@ const validateIndividualHedTag = function(
       checkCapitalization(
         originalTag,
         formattedTag,
-        hedSchema,
+        hedSchemas,
         doSemanticValidation,
       ),
     )
@@ -530,7 +555,7 @@ const validateIndividualHedTag = function(
  */
 const validateIndividualHedTags = function(
   parsedString,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
   checkForWarnings,
   allowPlaceholders = false,
@@ -547,7 +572,7 @@ const validateIndividualHedTags = function(
         formattedTag,
         previousOriginalTag,
         previousFormattedTag,
-        hedSchema,
+        hedSchemas,
         doSemanticValidation,
         checkForWarnings,
         allowPlaceholders,
@@ -565,13 +590,13 @@ const validateIndividualHedTags = function(
 const validateHedTagLevel = function(
   originalTagList,
   formattedTagList,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
 ) {
   let issues = []
   if (doSemanticValidation) {
     issues = issues.concat(
-      checkForMultipleUniqueTags(originalTagList, formattedTagList, hedSchema),
+      checkForMultipleUniqueTags(originalTagList, formattedTagList, hedSchemas),
     )
   }
   issues = issues.concat(
@@ -585,7 +610,7 @@ const validateHedTagLevel = function(
  */
 const validateHedTagLevels = function(
   parsedString,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
 ) {
   let issues = []
@@ -593,14 +618,14 @@ const validateHedTagLevels = function(
     const originalTagList = parsedString.tagGroups[i]
     const formattedTagList = parsedString.formattedTagGroups[i]
     issues = issues.concat(
-      validateHedTagLevel(originalTagList, formattedTagList, hedSchema),
+      validateHedTagLevel(originalTagList, formattedTagList, hedSchemas),
     )
   }
   issues = issues.concat(
     validateHedTagLevel(
       parsedString.topLevelTags,
       parsedString.formattedTopLevelTags,
-      hedSchema,
+      hedSchemas,
       doSemanticValidation,
     ),
   )
@@ -632,12 +657,12 @@ const validateHedTagGroups = function(parsedString) {
  */
 const validateTopLevelTags = function(
   parsedString,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
   checkForWarnings,
 ) {
   if (doSemanticValidation && checkForWarnings) {
-    return checkForRequiredTags(parsedString, hedSchema)
+    return checkForRequiredTags(parsedString, hedSchemas)
   } else {
     return []
   }
@@ -647,23 +672,25 @@ const validateTopLevelTags = function(
  * Perform initial validation on a HED string and parse it so further validation can be performed.
  *
  * @param {string} hedString The HED string to validate.
- * @param {Schema} hedSchema The HED schema to validate against.
+ * @param {Schemas} hedSchemas The HED schemas to validate against.
  * @param {boolean} doSemanticValidation Whether to perform semantic validation.
  * @return {Array} Whether validation passed, any issues, and any parsed string data.
  */
 const initiallyValidateHedString = function(
   hedString,
-  hedSchema,
+  hedSchemas,
   doSemanticValidation,
 ) {
   if (doSemanticValidation) {
-    if (!hedSchema.attributes) {
-      hedSchema.attributes = buildSchemaAttributesObject(hedSchema.xmlData)
+    if (!hedSchemas.baseSchema.attributes) {
+      hedSchemas.baseSchema.attributes = buildSchemaAttributesObject(
+        hedSchemas.baseSchema.xmlData,
+      )
     }
-    if (hedSchema.mapping) {
+    if (hedSchemas.baseSchema.mapping) {
       let hedStringConversionIssues
       ;[hedString, hedStringConversionIssues] = convertHedStringToLong(
-        hedSchema,
+        hedSchemas,
         hedString,
       )
       if (hedStringConversionIssues.length !== 0) {
@@ -690,23 +717,23 @@ const initiallyValidateHedString = function(
  * Validate a HED string.
  *
  * @param {string} hedString The HED string to validate.
- * @param {Schema} hedSchema The HED schema to validate against.
+ * @param {Schemas} hedSchemas The HED schemas to validate against.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @param {boolean} allowPlaceholders Whether to treat value-taking tags with '#' placeholders as valid.
  * @returns {[boolean, Issue[]]} Whether the HED string is valid and any issues found.
  */
 const validateHedString = function(
   hedString,
-  hedSchema,
+  hedSchemas,
   checkForWarnings = false,
   allowPlaceholders = false,
 ) {
-  const doSemanticValidation = hedSchema instanceof Schema
+  const doSemanticValidation = hedSchemas instanceof Schemas
   const [
     initiallyValid,
     initialIssues,
     parsedString,
-  ] = initiallyValidateHedString(hedString, hedSchema, doSemanticValidation)
+  ] = initiallyValidateHedString(hedString, hedSchemas, doSemanticValidation)
   if (!initiallyValid) {
     return [false, initialIssues]
   }
@@ -714,7 +741,7 @@ const validateHedString = function(
   const issues = initialIssues.concat(
     validateIndividualHedTags(
       parsedString,
-      hedSchema,
+      hedSchemas,
       doSemanticValidation,
       checkForWarnings,
       allowPlaceholders,
@@ -732,21 +759,21 @@ const validateHedString = function(
  * Validate a HED event string.
  *
  * @param {string} hedString The HED event string to validate.
- * @param {Schema} hedSchema The HED schema to validate against.
+ * @param {Schemas} hedSchemas The HED schemas to validate against.
  * @param {boolean} checkForWarnings Whether to check for warnings or only errors.
  * @returns {[boolean, Issue[]]} Whether the HED string is valid and any issues found.
  */
 const validateHedEvent = function(
   hedString,
-  hedSchema,
+  hedSchemas,
   checkForWarnings = false,
 ) {
-  const doSemanticValidation = hedSchema instanceof Schema
+  const doSemanticValidation = hedSchemas instanceof Schemas
   const [
     initiallyValid,
     initialIssues,
     parsedString,
-  ] = initiallyValidateHedString(hedString, hedSchema, doSemanticValidation)
+  ] = initiallyValidateHedString(hedString, hedSchemas, doSemanticValidation)
   if (!initiallyValid) {
     return [false, initialIssues]
   }
@@ -754,17 +781,17 @@ const validateHedEvent = function(
   const issues = initialIssues.concat(
     validateTopLevelTags(
       parsedString,
-      hedSchema,
+      hedSchemas,
       doSemanticValidation,
       checkForWarnings,
     ),
     validateIndividualHedTags(
       parsedString,
-      hedSchema,
+      hedSchemas,
       doSemanticValidation,
       checkForWarnings,
     ),
-    validateHedTagLevels(parsedString, hedSchema, doSemanticValidation),
+    validateHedTagLevels(parsedString, hedSchemas, doSemanticValidation),
     validateHedTagGroups(parsedString),
   )
   if (issues.length === 0) {

--- a/validator/schema.js
+++ b/validator/schema.js
@@ -1,5 +1,3 @@
-const semver = require('semver')
-
 // TODO: Switch require once upstream bugs are fixed.
 // const xpath = require('xml2js-xpath')
 // Temporary
@@ -39,7 +37,7 @@ const unitsElement = 'units'
 const unitModifierElement = 'unitModifier'
 
 const SchemaDictionaries = {
-  populateDictionaries: function() {
+  populateDictionaries: function () {
     this.dictionaries = {}
     this.populateUnitClassDictionaries()
     this.populateUnitModifierDictionaries()
@@ -47,17 +45,17 @@ const SchemaDictionaries = {
     return this.dictionaries
   },
 
-  populateTagDictionaries: function() {
+  populateTagDictionaries: function () {
     for (const dictionaryKey of tagDictionaryKeys) {
       const [tags, tagElements] = this.getTagsByAttribute(dictionaryKey)
       if (dictionaryKey === extensionAllowedAttribute) {
         const tagDictionary = this.stringListToLowercaseDictionary(tags)
         const childTagElements = arrayUtils.flattenDeep(
-          tagElements.map(tagElement => {
+          tagElements.map((tagElement) => {
             return this.getAllChildTags(tagElement)
           }),
         )
-        const childTags = childTagElements.map(tagElement => {
+        const childTags = childTagElements.map((tagElement) => {
           return this.getTagPathFromTagElement(tagElement)
         })
         const childDictionary = this.stringListToLowercaseDictionary(childTags)
@@ -84,7 +82,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateUnitClassDictionaries: function() {
+  populateUnitClassDictionaries: function () {
     const unitClassElements = this.getElementsByName(unitClassElement)
     if (unitClassElements.length === 0) {
       this.hasUnitClasses = false
@@ -95,7 +93,7 @@ const SchemaDictionaries = {
     this.populateUnitClassDefaultUnitDictionary(unitClassElements)
   },
 
-  populateUnitClassUnitsDictionary: function(unitClassElements) {
+  populateUnitClassUnitsDictionary: function (unitClassElements) {
     this.dictionaries[unitsElement] = {}
     for (const unitClassKey of unitClassDictionaryKeys) {
       this.dictionaries[unitClassKey] = {}
@@ -110,12 +108,12 @@ const SchemaDictionaries = {
           unitClassUnitsElement,
         )
         const units = elementUnits.split(',')
-        this.dictionaries[unitsElement][unitClassName] = units.map(unit => {
+        this.dictionaries[unitsElement][unitClassName] = units.map((unit) => {
           return unit.toLowerCase()
         })
         continue
       }
-      const unitNames = units.map(element => {
+      const unitNames = units.map((element) => {
         return element._
       })
       this.dictionaries[unitsElement][unitClassName] = unitNames
@@ -130,7 +128,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateUnitClassDefaultUnitDictionary: function(unitClassElements) {
+  populateUnitClassDefaultUnitDictionary: function (unitClassElements) {
     this.dictionaries[defaultUnitForUnitClassAttribute] = {}
     for (const unitClassElement of unitClassElements) {
       const elementName = this.getElementTagValue(unitClassElement)
@@ -146,7 +144,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateUnitModifierDictionaries: function() {
+  populateUnitModifierDictionaries: function () {
     const unitModifierElements = this.getElementsByName(unitModifierElement)
     if (unitModifierElements.length === 0) {
       this.hasUnitModifiers = false
@@ -169,7 +167,7 @@ const SchemaDictionaries = {
     }
   },
 
-  populateTagToAttributeDictionary: function(
+  populateTagToAttributeDictionary: function (
     tagList,
     tagElementList,
     attributeName,
@@ -182,7 +180,7 @@ const SchemaDictionaries = {
     }
   },
 
-  stringListToLowercaseDictionary: function(stringList) {
+  stringListToLowercaseDictionary: function (stringList) {
     const lowercaseDictionary = {}
     for (const stringElement of stringList) {
       lowercaseDictionary[stringElement.toLowerCase()] = stringElement
@@ -190,7 +188,7 @@ const SchemaDictionaries = {
     return lowercaseDictionary
   },
 
-  getAncestorTagNames: function(tagElement) {
+  getAncestorTagNames: function (tagElement) {
     const ancestorTags = []
     let parentTagName = this.getParentTagName(tagElement)
     let parentElement = tagElement.$parent
@@ -202,11 +200,11 @@ const SchemaDictionaries = {
     return ancestorTags
   },
 
-  getElementTagValue: function(element, tagName = 'name') {
+  getElementTagValue: function (element, tagName = 'name') {
     return element[tagName][0]._
   },
 
-  getParentTagName: function(tagElement) {
+  getParentTagName: function (tagElement) {
     const parentTagElement = tagElement.$parent
     if (parentTagElement && parentTagElement !== this.rootElement) {
       return parentTagElement.name[0]._
@@ -215,14 +213,14 @@ const SchemaDictionaries = {
     }
   },
 
-  getTagPathFromTagElement: function(tagElement) {
+  getTagPathFromTagElement: function (tagElement) {
     const ancestorTagNames = this.getAncestorTagNames(tagElement)
     ancestorTagNames.unshift(this.getElementTagValue(tagElement))
     ancestorTagNames.reverse()
     return ancestorTagNames.join('/')
   },
 
-  getTagsByAttribute: function(attributeName) {
+  getTagsByAttribute: function (attributeName) {
     const tags = []
     const tagElements = xpath.find(
       this.rootElement,
@@ -235,7 +233,7 @@ const SchemaDictionaries = {
     return [tags, tagElements]
   },
 
-  getAllTags: function(tagElementName = 'node', excludeTakeValueTags = true) {
+  getAllTags: function (tagElementName = 'node', excludeTakeValueTags = true) {
     const tags = []
     const tagElements = xpath.find(this.rootElement, '//' + tagElementName)
     for (const tagElement of tagElements) {
@@ -248,7 +246,10 @@ const SchemaDictionaries = {
     return [tags, tagElements]
   },
 
-  getElementsByName: function(elementName = 'node', parentElement = undefined) {
+  getElementsByName: function (
+    elementName = 'node',
+    parentElement = undefined,
+  ) {
     if (!parentElement) {
       return xpath.find(this.rootElement, '//' + elementName)
     } else {
@@ -256,7 +257,7 @@ const SchemaDictionaries = {
     }
   },
 
-  getAllChildTags: function(
+  getAllChildTags: function (
     parentElement,
     elementName = 'node',
     excludeTakeValueTags = true,
@@ -272,7 +273,7 @@ const SchemaDictionaries = {
       parentElement,
     )
     const childTags = arrayUtils.flattenDeep(
-      tagElementChildren.map(child => {
+      tagElementChildren.map((child) => {
         return this.getAllChildTags(child, elementName, excludeTakeValueTags)
       }),
     )
@@ -288,7 +289,7 @@ const SchemaDictionaries = {
  * @param {string} tagAttribute The attribute to check for.
  * @return {boolean} Whether this tag has this attribute.
  */
-const tagHasAttribute = function(tag, tagAttribute) {
+const tagHasAttribute = function (tag, tagAttribute) {
   return tag.toLowerCase() in this.dictionaries[tagAttribute]
 }
 
@@ -300,7 +301,7 @@ const tagHasAttribute = function(tag, tagAttribute) {
  * @param {boolean} hasUnitModifiers Whether the schema has unit modifiers.
  * @constructor
  */
-const SchemaAttributes = function(
+const SchemaAttributes = function (
   dictionaries,
   hasUnitClasses,
   hasUnitModifiers,
@@ -317,7 +318,7 @@ const SchemaAttributes = function(
  * @param {object} xmlData The schema XML data.
  * @return {SchemaAttributes} The schema attributes object.
  */
-const buildSchemaAttributesObject = function(xmlData) {
+const buildSchemaAttributesObject = function (xmlData) {
   const schemaDictionaries = Object.create(SchemaDictionaries)
   const rootElement = xmlData.HED
   schemaUtils.setParent(rootElement, xmlData)
@@ -336,13 +337,10 @@ const buildSchemaAttributesObject = function(xmlData) {
  * @param {{path: string?, version: string?}} schemaDef The description of which base schema to use.
  * @return {Promise<never>|Promise<Schemas>} The schema container object or an error.
  */
-const buildSchema = function(schemaDef = {}) {
-  return schemaUtils.loadSchema(schemaDef).then(xmlData => {
+const buildSchema = function (schemaDef = {}) {
+  return schemaUtils.loadSchema(schemaDef).then((xmlData) => {
     const schemaAttributes = buildSchemaAttributesObject(xmlData)
-    let mapping
-    if (semver.gte(xmlData.HED.$.version, '8.0.0-alpha')) {
-      mapping = buildMappingObject(xmlData)
-    }
+    const mapping = buildMappingObject(xmlData)
     const baseSchema = new schemaUtils.Schema(
       xmlData,
       schemaAttributes,

--- a/validator/schema.js
+++ b/validator/schema.js
@@ -331,10 +331,10 @@ const buildSchemaAttributesObject = function(xmlData) {
 }
 
 /**
- * Build a schema object from a schema version or path description.
+ * Build a schema container object from a base schema version or path description.
  *
- * @param {{path: string?, version: string?}} schemaDef The description of which schema to use.
- * @return {Promise<never>|Promise<Schema>} The schema object or an error.
+ * @param {{path: string?, version: string?}} schemaDef The description of which base schema to use.
+ * @return {Promise<never>|Promise<Schemas>} The schema container object or an error.
  */
 const buildSchema = function(schemaDef = {}) {
   return schemaUtils.loadSchema(schemaDef).then(xmlData => {
@@ -343,7 +343,12 @@ const buildSchema = function(schemaDef = {}) {
     if (semver.gte(xmlData.HED.$.version, '8.0.0-alpha')) {
       mapping = buildMappingObject(xmlData)
     }
-    return new schemaUtils.Schema(xmlData, schemaAttributes, mapping)
+    const baseSchema = new schemaUtils.Schema(
+      xmlData,
+      schemaAttributes,
+      mapping,
+    )
+    return new schemaUtils.Schemas(baseSchema)
   })
 }
 

--- a/validator/stringParser.js
+++ b/validator/stringParser.js
@@ -53,6 +53,40 @@ const ParsedHedTag = function (originalTag, originalBounds, hedSchemas) {
 }
 
 /**
+ * A parsed HED string.
+ *
+ * @param {string} hedString The original HED string.
+ * @constructor
+ */
+const ParsedHedString = function (hedString) {
+  /**
+   * The original HED string.
+   * @type {string}
+   */
+  this.hedString = hedString
+  /**
+   * All of the tags in the string.
+   * @type ParsedHedTag[]
+   */
+  this.tags = []
+  /**
+   * The tag groups in the string, split into arrays.
+   * @type ParsedHedTag[][]
+   */
+  this.tagGroups = []
+  /**
+   * The tag groups, kept in their original parenthesized form.
+   * @type ParsedHedTag[]
+   */
+  this.tagGroupStrings = []
+  /**
+   * All of the top-level tags in the string.
+   * @type ParsedHedTag[]
+   */
+  this.topLevelTags = []
+}
+
+/**
  * Determine whether a HED string is a group (surrounded by parentheses).
  *
  * @param {string} hedString A HED string.
@@ -167,8 +201,8 @@ const splitHedString = function (hedString, hedSchemas) {
  *
  * @param {ParsedHedTag[]} groupTagsList The list of possible group tags.
  * @param {Schemas} hedSchemas The collection of HED schemas.
- * @param {object} parsedString The object to store parsed output in.
- * @return {Array} The array of issues.
+ * @param {ParsedHedString} parsedString The object to store parsed output in.
+ * @return {Issue[]} The array of issues.
  */
 const findTagGroups = function (groupTagsList, hedSchemas, parsedString) {
   let issues = []
@@ -200,8 +234,8 @@ const findTagGroups = function (groupTagsList, hedSchemas, parsedString) {
  *
  * @param {ParsedHedTag[]} hedTags A list of split HED tags.
  * @param {Schemas} hedSchemas The collection of HED schemas.
- * @param {object} parsedString The object to store sorted output in.
- * @returns {Array} The top-level tags from a HED string.
+ * @param {ParsedHedString} parsedString The object to store sorted output in.
+ * @returns {ParsedHedTag[]} The top-level tags from a HED string.
  */
 const findTopLevelTags = function (hedTags, hedSchemas, parsedString) {
   const topLevelTags = []
@@ -219,7 +253,7 @@ const findTopLevelTags = function (hedTags, hedSchemas, parsedString) {
 /**
  * Format the HED tags in a list.
  *
- * @param {ParsedHedTag[]} hedTagList An array of unformatted HED tags.
+ * @param {ParsedHedTag[]|ParsedHedTag[][]} hedTagList An array of unformatted HED tags.
  * @returns {Array} An array of formatted HED tags corresponding to hedTagList.
  */
 const formatHedTagsInList = function (hedTagList) {
@@ -261,15 +295,10 @@ const formatHedTag = function (hedTag) {
  *
  * @param {string} hedString The full HED string to parse.
  * @param {Schemas} hedSchemas The collection of HED schemas.
- * @returns {[{tagGroups: ParsedHedTag[][], tagGroupStrings: ParsedHedTag[], topLevelTags: ParsedHedTag[], tags: ParsedHedTag[]}, Array]} The parsed HED tag data and list of issues.
+ * @returns {[ParsedHedString, Issue[]]} The parsed HED tag data and list of issues.
  */
 const parseHedString = function (hedString, hedSchemas) {
-  const parsedString = {
-    tags: [],
-    tagGroups: [],
-    tagGroupStrings: [],
-    topLevelTags: [],
-  }
+  const parsedString = new ParsedHedString(hedString)
   const [hedTagList, splitIssues] = splitHedString(hedString, hedSchemas)
   parsedString.topLevelTags = findTopLevelTags(
     hedTagList,
@@ -286,6 +315,7 @@ const parseHedString = function (hedString, hedSchemas) {
 
 module.exports = {
   ParsedHedTag: ParsedHedTag,
+  ParsedHedString: ParsedHedString,
   hedStringIsAGroup: hedStringIsAGroup,
   removeGroupParentheses: removeGroupParentheses,
   splitHedString: splitHedString,

--- a/validator/stringParser.js
+++ b/validator/stringParser.js
@@ -79,16 +79,15 @@ const removeGroupParentheses = function (tagGroup) {
  *
  * @param {string} hedString The full HED string.
  * @param {Schemas} hedSchemas The collection of HED schemas.
- * @param {Array} issues The array of issues.
- * @returns {ParsedHedTag[]} An array of HED tags (top-level relative to the passed string).
+ * @returns {[ParsedHedTag[], Array]} An array of HED tags (top-level relative to the passed string) and any issues found.
  */
-const splitHedString = function (hedString, hedSchemas, issues) {
+const splitHedString = function (hedString, hedSchemas) {
   const delimiter = ','
   const doubleQuoteCharacter = '"'
-  const tilde = '~'
-  const invalidCharacters = ['{', '}', '[', ']']
+  const invalidCharacters = ['{', '}', '[', ']', '~']
 
   const hedTags = []
+  let issues = []
   let groupDepth = 0
   let currentTag = ''
   let startingIndex = 0
@@ -109,22 +108,16 @@ const splitHedString = function (hedString, hedSchemas, issues) {
     } else if (character === closingGroupCharacter) {
       groupDepth--
     }
-    if (groupDepth === 0 && character === tilde) {
-      // Found a tilde, so push the current tag and a tilde.
-      if (!utils.string.stringIsEmpty(currentTag)) {
-        hedTags.push(
-          new ParsedHedTag(currentTag.trim(), [startingIndex, i], hedSchemas),
-        )
-      }
-      hedTags.push(new ParsedHedTag(tilde, [i, i + 1], hedSchemas))
-      resetStartingIndex = true
-      currentTag = ''
-    } else if (groupDepth === 0 && character === delimiter) {
+    if (groupDepth === 0 && character === delimiter) {
       // Found the end of a tag, so push the current tag.
       if (!utils.string.stringIsEmpty(currentTag)) {
-        hedTags.push(
-          new ParsedHedTag(currentTag.trim(), [startingIndex, i], hedSchemas),
+        const parsedHedTag = new ParsedHedTag(
+          currentTag.trim(),
+          [startingIndex, i],
+          hedSchemas,
         )
+        hedTags.push(parsedHedTag)
+        issues = issues.concat(parsedHedTag.conversionIssues)
       }
       resetStartingIndex = true
       currentTag = ''
@@ -138,9 +131,13 @@ const splitHedString = function (hedString, hedSchemas, issues) {
         }),
       )
       if (!utils.string.stringIsEmpty(currentTag)) {
-        hedTags.push(
-          new ParsedHedTag(currentTag.trim(), [startingIndex, i], hedSchemas),
+        const parsedHedTag = new ParsedHedTag(
+          currentTag.trim(),
+          [startingIndex, i],
+          hedSchemas,
         )
+        hedTags.push(parsedHedTag)
+        issues = issues.concat(parsedHedTag.conversionIssues)
       }
       resetStartingIndex = true
       currentTag = ''
@@ -154,15 +151,15 @@ const splitHedString = function (hedString, hedSchemas, issues) {
   }
   if (!utils.string.stringIsEmpty(currentTag)) {
     // Push last HED tag.
-    hedTags.push(
-      new ParsedHedTag(
-        currentTag.trim(),
-        [startingIndex, hedString.length],
-        hedSchemas,
-      ),
+    const parsedHedTag = new ParsedHedTag(
+      currentTag.trim(),
+      [startingIndex, hedString.length],
+      hedSchemas,
     )
+    hedTags.push(parsedHedTag)
+    issues = issues.concat(parsedHedTag.conversionIssues)
   }
-  return hedTags
+  return [hedTags, issues]
 }
 
 /**
@@ -171,30 +168,31 @@ const splitHedString = function (hedString, hedSchemas, issues) {
  * @param {ParsedHedTag[]} groupTagsList The list of possible group tags.
  * @param {Schemas} hedSchemas The collection of HED schemas.
  * @param {object} parsedString The object to store parsed output in.
- * @param {Array} issues The array of issues.
+ * @return {Array} The array of issues.
  */
-const findTagGroups = function (
-  groupTagsList,
-  hedSchemas,
-  parsedString,
-  issues,
-) {
+const findTagGroups = function (groupTagsList, hedSchemas, parsedString) {
+  let issues = []
   for (const tagOrGroup of groupTagsList) {
     if (hedStringIsAGroup(tagOrGroup.originalTag)) {
       const tagGroupString = removeGroupParentheses(tagOrGroup.originalTag)
       // Split the group tag and recurse.
-      const nestedGroupTagList = splitHedString(
+      const [nestedGroupTagList, nestedGroupIssues] = splitHedString(
         tagGroupString,
         hedSchemas,
-        issues,
       )
-      findTagGroups(nestedGroupTagList, hedSchemas, parsedString, issues)
+      const nestedIssues = findTagGroups(
+        nestedGroupTagList,
+        hedSchemas,
+        parsedString,
+      )
       parsedString.tagGroupStrings.push(tagOrGroup)
       parsedString.tagGroups.push(nestedGroupTagList)
+      issues = issues.concat(nestedGroupIssues, nestedIssues)
     } else if (!parsedString.tags.includes(tagOrGroup)) {
       parsedString.tags.push(tagOrGroup)
     }
   }
+  return issues
 }
 
 /**
@@ -266,23 +264,23 @@ const formatHedTag = function (hedTag) {
  * @returns {[{tagGroups: ParsedHedTag[][], tagGroupStrings: ParsedHedTag[], topLevelTags: ParsedHedTag[], tags: ParsedHedTag[]}, Array]} The parsed HED tag data and list of issues.
  */
 const parseHedString = function (hedString, hedSchemas) {
-  const issues = []
   const parsedString = {
     tags: [],
     tagGroups: [],
     tagGroupStrings: [],
     topLevelTags: [],
   }
-  const hedTagList = splitHedString(hedString, hedSchemas, issues)
+  const [hedTagList, splitIssues] = splitHedString(hedString, hedSchemas)
   parsedString.topLevelTags = findTopLevelTags(
     hedTagList,
     hedSchemas,
     parsedString,
   )
-  findTagGroups(hedTagList, hedSchemas, parsedString, issues)
+  const tagGroupIssues = findTagGroups(hedTagList, hedSchemas, parsedString)
   formatHedTagsInList(parsedString.tags)
   formatHedTagsInList(parsedString.tagGroups)
   formatHedTagsInList(parsedString.topLevelTags)
+  const issues = [].concat(splitIssues, tagGroupIssues)
   return [parsedString, issues]
 }
 

--- a/validator/stringParser.js
+++ b/validator/stringParser.js
@@ -1,12 +1,63 @@
 const utils = require('../utils')
+const { convertHedStringToLong } = require('../converter/converter')
 
 const openingGroupCharacter = '('
 const closingGroupCharacter = ')'
 
 /**
- * Determine whether a HED string is a group (surrounded by parentheses).
+ * A parsed HED tag.
+ *
+ * @param {string} originalTag The original HED tag.
+ * @param {int[]} originalBounds The bounds of the HED tag in the original HED string.
+ * @param {Schemas} hedSchemas The collection of HED schemas.
+ * @constructor
  */
-const hedStringIsAGroup = function(hedString) {
+const ParsedHedTag = function (originalTag, originalBounds, hedSchemas) {
+  /**
+   * The original form of the HED tag.
+   * @type {string}
+   */
+  this.originalTag = originalTag
+  /**
+   * The bounds of the HED tag in the original HED string.
+   * @type {int[]}
+   */
+  this.originalBounds = originalBounds
+  /**
+   * The formatted canonical version of the HED tag.
+   *
+   * The empty string default value should be replaced during formatting. Failure to do so
+   * signals an error, as an empty tag should never happen.
+   * @type {string}
+   */
+  this.formattedTag = ''
+  if (hedSchemas.isHed3) {
+    const [canonicalTag, conversionIssues] = convertHedStringToLong(
+      hedSchemas,
+      originalTag,
+    )
+    /**
+     * The canonical form of the HED tag.
+     * @type {string}
+     */
+    this.canonicalTag = canonicalTag
+    /**
+     * Any issues encountered during tag conversion.
+     * @type {Array}
+     */
+    this.conversionIssues = conversionIssues
+  } else {
+    this.canonicalTag = originalTag
+    this.conversionIssues = []
+  }
+}
+
+/**
+ * Determine whether a HED string is a group (surrounded by parentheses).
+ *
+ * @param {string} hedString A HED string.
+ */
+const hedStringIsAGroup = function (hedString) {
   const trimmedHedString = hedString.trim()
   return (
     trimmedHedString.startsWith(openingGroupCharacter) &&
@@ -16,8 +67,10 @@ const hedStringIsAGroup = function(hedString) {
 
 /**
  * Return a copy of a group tag with the surrounding parentheses removed.
+ *
+ * @param {string} tagGroup A tag group string.
  */
-const removeGroupParentheses = function(tagGroup) {
+const removeGroupParentheses = function (tagGroup) {
   return tagGroup.slice(1, -1)
 }
 
@@ -25,10 +78,11 @@ const removeGroupParentheses = function(tagGroup) {
  * Split a full HED string into tags.
  *
  * @param {string} hedString The full HED string.
+ * @param {Schemas} hedSchemas The collection of HED schemas.
  * @param {Array} issues The array of issues.
- * @returns {Array} An array of HED tags (top-level relative to the passed string).
+ * @returns {ParsedHedTag[]} An array of HED tags (top-level relative to the passed string).
  */
-const splitHedString = function(hedString, issues) {
+const splitHedString = function (hedString, hedSchemas, issues) {
   const delimiter = ','
   const doubleQuoteCharacter = '"'
   const tilde = '~'
@@ -37,8 +91,14 @@ const splitHedString = function(hedString, issues) {
   const hedTags = []
   let groupDepth = 0
   let currentTag = ''
+  let startingIndex = 0
+  let resetStartingIndex = false
   // Loop a character at a time.
   for (let i = 0; i < hedString.length; i++) {
+    if (resetStartingIndex) {
+      startingIndex = i
+      resetStartingIndex = false
+    }
     const character = hedString.charAt(i)
     if (character === doubleQuoteCharacter) {
       // Skip double quotes
@@ -52,15 +112,21 @@ const splitHedString = function(hedString, issues) {
     if (groupDepth === 0 && character === tilde) {
       // Found a tilde, so push the current tag and a tilde.
       if (!utils.string.stringIsEmpty(currentTag)) {
-        hedTags.push(currentTag.trim())
+        hedTags.push(
+          new ParsedHedTag(currentTag.trim(), [startingIndex, i], hedSchemas),
+        )
       }
-      hedTags.push(tilde)
+      hedTags.push(new ParsedHedTag(tilde, [i, i + 1], hedSchemas))
+      resetStartingIndex = true
       currentTag = ''
     } else if (groupDepth === 0 && character === delimiter) {
       // Found the end of a tag, so push the current tag.
       if (!utils.string.stringIsEmpty(currentTag)) {
-        hedTags.push(currentTag.trim())
+        hedTags.push(
+          new ParsedHedTag(currentTag.trim(), [startingIndex, i], hedSchemas),
+        )
       }
+      resetStartingIndex = true
       currentTag = ''
     } else if (invalidCharacters.includes(character)) {
       // Found an invalid character, so push an issue.
@@ -72,16 +138,29 @@ const splitHedString = function(hedString, issues) {
         }),
       )
       if (!utils.string.stringIsEmpty(currentTag)) {
-        hedTags.push(currentTag.trim())
+        hedTags.push(
+          new ParsedHedTag(currentTag.trim(), [startingIndex, i], hedSchemas),
+        )
       }
+      resetStartingIndex = true
       currentTag = ''
     } else {
       currentTag += character
+      if (utils.string.stringIsEmpty(currentTag)) {
+        resetStartingIndex = true
+        currentTag = ''
+      }
     }
   }
   if (!utils.string.stringIsEmpty(currentTag)) {
     // Push last HED tag.
-    hedTags.push(currentTag.trim())
+    hedTags.push(
+      new ParsedHedTag(
+        currentTag.trim(),
+        [startingIndex, hedString.length],
+        hedSchemas,
+      ),
+    )
   }
   return hedTags
 }
@@ -89,17 +168,27 @@ const splitHedString = function(hedString, issues) {
 /**
  * Find and parse the group tags in a provided list.
  *
- * @param {Array} groupTagsList The list of possible group tags.
+ * @param {ParsedHedTag[]} groupTagsList The list of possible group tags.
+ * @param {Schemas} hedSchemas The collection of HED schemas.
  * @param {object} parsedString The object to store parsed output in.
  * @param {Array} issues The array of issues.
  */
-const findTagGroups = function(groupTagsList, parsedString, issues) {
+const findTagGroups = function (
+  groupTagsList,
+  hedSchemas,
+  parsedString,
+  issues,
+) {
   for (const tagOrGroup of groupTagsList) {
-    if (hedStringIsAGroup(tagOrGroup)) {
-      const tagGroupString = removeGroupParentheses(tagOrGroup)
+    if (hedStringIsAGroup(tagOrGroup.originalTag)) {
+      const tagGroupString = removeGroupParentheses(tagOrGroup.originalTag)
       // Split the group tag and recurse.
-      const nestedGroupTagList = splitHedString(tagGroupString, issues)
-      findTagGroups(nestedGroupTagList, parsedString, issues)
+      const nestedGroupTagList = splitHedString(
+        tagGroupString,
+        hedSchemas,
+        issues,
+      )
+      findTagGroups(nestedGroupTagList, hedSchemas, parsedString, issues)
       parsedString.tagGroupStrings.push(tagOrGroup)
       parsedString.tagGroups.push(nestedGroupTagList)
     } else if (!parsedString.tags.includes(tagOrGroup)) {
@@ -111,14 +200,15 @@ const findTagGroups = function(groupTagsList, parsedString, issues) {
 /**
  * Find top-level tags in a split HED tag list.
  *
- * @param {string[]} hedTags A list of split HED tags.
+ * @param {ParsedHedTag[]} hedTags A list of split HED tags.
+ * @param {Schemas} hedSchemas The collection of HED schemas.
  * @param {object} parsedString The object to store sorted output in.
  * @returns {Array} The top-level tags from a HED string.
  */
-const findTopLevelTags = function(hedTags, parsedString) {
+const findTopLevelTags = function (hedTags, hedSchemas, parsedString) {
   const topLevelTags = []
   for (const tagOrGroup of hedTags) {
-    if (!hedStringIsAGroup(tagOrGroup)) {
+    if (!hedStringIsAGroup(tagOrGroup.originalTag)) {
       topLevelTags.push(tagOrGroup)
       if (!parsedString.tags.includes(tagOrGroup)) {
         parsedString.tags.push(tagOrGroup)
@@ -131,63 +221,51 @@ const findTopLevelTags = function(hedTags, parsedString) {
 /**
  * Format the HED tags in a list.
  *
- * @param {string[]} hedTagList An array of unformatted HED tags.
- * @param {boolean} onlyRemoveNewLine Whether to only remove newlines.
+ * @param {ParsedHedTag[]} hedTagList An array of unformatted HED tags.
  * @returns {Array} An array of formatted HED tags corresponding to hedTagList.
  */
-const formatHedTagsInList = function(hedTagList, onlyRemoveNewLine = false) {
-  const formattedTagList = []
+const formatHedTagsInList = function (hedTagList) {
   for (const hedTag of hedTagList) {
     if (hedTag instanceof Array) {
       // Recurse
-      const nestedFormattedTagList = formatHedTagsInList(
-        hedTag,
-        onlyRemoveNewLine,
-      )
-      formattedTagList.push(nestedFormattedTagList)
+      formatHedTagsInList(hedTag)
     } else {
-      const formattedHedTag = formatHedTag(hedTag, onlyRemoveNewLine)
-      formattedTagList.push(formattedHedTag)
+      formatHedTag(hedTag)
     }
   }
-  return formattedTagList
 }
 
 /**
- * Format an individual HED tag by removing newlines, and optionally double quotes and slashes.
+ * Format an individual HED tag by removing newlines, double quotes, and slashes.
  *
- * @param {string} hedTag The HED tag to format.
- * @param {boolean} onlyRemoveNewLine Whether to only remove newlines.
- * @returns {string} The formatted HED tag.
+ * @param {ParsedHedTag} hedTag The HED tag to format.
  */
-const formatHedTag = function(hedTag, onlyRemoveNewLine = false) {
-  hedTag = hedTag.replace('\n', ' ')
-  if (onlyRemoveNewLine) {
-    return hedTag
+const formatHedTag = function (hedTag) {
+  hedTag.originalTag = hedTag.originalTag.replace('\n', ' ')
+  let hedTagString = hedTag.canonicalTag.trim()
+  if (hedTagString.startsWith('"')) {
+    hedTagString = hedTagString.slice(1)
   }
-  hedTag = hedTag.trim()
-  if (hedTag.startsWith('"')) {
-    hedTag = hedTag.slice(1)
+  if (hedTagString.endsWith('"')) {
+    hedTagString = hedTagString.slice(0, -1)
   }
-  if (hedTag.endsWith('"')) {
-    hedTag = hedTag.slice(0, -1)
+  if (hedTagString.startsWith('/')) {
+    hedTagString = hedTagString.slice(1)
   }
-  if (hedTag.startsWith('/')) {
-    hedTag = hedTag.slice(1)
+  if (hedTagString.endsWith('/')) {
+    hedTagString = hedTagString.slice(0, -1)
   }
-  if (hedTag.endsWith('/')) {
-    hedTag = hedTag.slice(0, -1)
-  }
-  return hedTag.toLowerCase()
+  hedTag.formattedTag = hedTagString.toLowerCase()
 }
 
 /**
  * Parse a full HED string into a object of tag types.
  *
  * @param {string} hedString The full HED string to parse.
- * @returns {[{tagGroups: Array, tagGroupStrings: Array, topLevelTags: Array, tags: Array, formattedTagGroups: Array, formattedTopLevelTags: Array, formattedTags: Array}, Array]} The parsed HED tag data and list of issues.
+ * @param {Schemas} hedSchemas The collection of HED schemas.
+ * @returns {[{tagGroups: ParsedHedTag[][], tagGroupStrings: ParsedHedTag[], topLevelTags: ParsedHedTag[], tags: ParsedHedTag[]}, Array]} The parsed HED tag data and list of issues.
  */
-const parseHedString = function(hedString) {
+const parseHedString = function (hedString, hedSchemas) {
   const issues = []
   const parsedString = {
     tags: [],
@@ -195,24 +273,21 @@ const parseHedString = function(hedString) {
     tagGroupStrings: [],
     topLevelTags: [],
   }
-  const hedTagList = splitHedString(hedString, issues)
-  parsedString.topLevelTags = findTopLevelTags(hedTagList, parsedString)
-  findTagGroups(hedTagList, parsedString, issues)
-  parsedString.tags = formatHedTagsInList(parsedString.tags, true)
-  parsedString.tagGroups = formatHedTagsInList(parsedString.tagGroups, true)
-  parsedString.topLevelTags = formatHedTagsInList(
-    parsedString.topLevelTags,
-    true,
+  const hedTagList = splitHedString(hedString, hedSchemas, issues)
+  parsedString.topLevelTags = findTopLevelTags(
+    hedTagList,
+    hedSchemas,
+    parsedString,
   )
-  parsedString.formattedTags = formatHedTagsInList(parsedString.tags)
-  parsedString.formattedTagGroups = formatHedTagsInList(parsedString.tagGroups)
-  parsedString.formattedTopLevelTags = formatHedTagsInList(
-    parsedString.topLevelTags,
-  )
+  findTagGroups(hedTagList, hedSchemas, parsedString, issues)
+  formatHedTagsInList(parsedString.tags)
+  formatHedTagsInList(parsedString.tagGroups)
+  formatHedTagsInList(parsedString.topLevelTags)
   return [parsedString, issues]
 }
 
 module.exports = {
+  ParsedHedTag: ParsedHedTag,
   hedStringIsAGroup: hedStringIsAGroup,
   removeGroupParentheses: removeGroupParentheses,
   splitHedString: splitHedString,


### PR DESCRIPTION
This pull request adds a bevy of changes to the codebase:

 - String parsing refactored, with new types added and all tags now being passed through short-to-long conversion before performing semantic validation.
 - Tilde validation removed, and tildes are now treated as invalid.
 - New placeholder and definition syntax validation checks added.
 - Unit and value validation rewritten.
 - Several changes to tests.
 - Remote library schema loading support added.