### PR TITLE
Implement tag group and prefix unit attribute support

### DIFF
--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -428,6 +428,7 @@ describe('HED string and event validation', () => {
           correctSingularUnit: 'Event/Duration/1 millisecond',
           correctPluralUnit: 'Event/Duration/3 milliseconds',
           correctNoPluralUnit: 'Attribute/Temporal rate/3 hertz',
+          correctPrefixUnit: 'Participant/Effect/Cognitive/Reward/$19.69',
           correctNonSymbolCapitalizedUnit: 'Event/Duration/3 MilliSeconds',
           correctSymbolCapitalizedUnit: 'Attribute/Temporal rate/3 kHz',
           missingRequiredUnit: 'Event/Duration/3',
@@ -454,6 +455,7 @@ describe('HED string and event validation', () => {
           correctSingularUnit: [],
           correctPluralUnit: [],
           correctNoPluralUnit: [],
+          correctPrefixUnit: [],
           correctNonSymbolCapitalizedUnit: [],
           correctSymbolCapitalizedUnit: [],
           missingRequiredUnit: [
@@ -789,7 +791,7 @@ describe('HED string and event validation', () => {
           incorrectUnit: 'Event/Duration/3 cm',
           incorrectNonNumericValue: 'Event/Duration/A ms',
           incorrectUnitWord: 'Event/Duration/3 nanoseconds',
-          incorrectPrefix: 'Event/Duration/3 ns',
+          incorrectModifier: 'Event/Duration/3 ns',
           notRequiredNumber: 'Attribute/Visual/Color/Red/0.5',
           notRequiredScientific: 'Attribute/Visual/Color/Red/5e-1',
           properTime: 'Item/2D shape/Clock face/08:30',
@@ -840,9 +842,9 @@ describe('HED string and event validation', () => {
               unitClassUnits: legalTimeUnits.sort().join(','),
             }),
           ],
-          incorrectPrefix: [
+          incorrectModifier: [
             generateIssue('unitClassInvalidUnit', {
-              tag: testStrings.incorrectPrefix,
+              tag: testStrings.incorrectModifier,
               unitClassUnits: legalTimeUnits.sort().join(','),
             }),
           ],

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -1293,24 +1293,67 @@ describe('HED string and event validation', () => {
         )
       }
 
-      it('should not have definitions at the top level', () => {
+      it('should not have invalid top-level tags', () => {
         const testStrings = {
-          definition: 'Definition/TopLevelDefinition',
-          defExpand: 'Def-expand/TopLevelDefExpand',
-          def: 'Def/TopLevelDefReference',
+          validDef: 'Def/TopLevelDefReference',
+          validDefExpand: '(Def-expand/ValidDefExpand)',
+          invalidDefExpand: 'Def-expand/InvalidDefExpand',
         }
         const expectedIssues = {
-          definition: [
-            generateIssue('topLevelDefinitionTag', {
-              tag: testStrings.definition,
+          validDef: [],
+          validDefExpand: [],
+          invalidDefExpand: [
+            generateIssue('invalidTopLevelTag', {
+              tag: testStrings.invalidDefExpand,
             }),
           ],
-          defExpand: [
-            generateIssue('topLevelDefinitionTag', {
-              tag: testStrings.defExpand,
+        }
+        return validatorSemantic(testStrings, expectedIssues)
+      })
+    })
+
+    describe('Top-level Group Tags', () => {
+      const validatorSyntactic = function (testStrings, expectedIssues) {
+        validatorSyntacticBase(
+          testStrings,
+          expectedIssues,
+          function (parsedTestString) {
+            return hed.validateTopLevelTagGroups(parsedTestString, {}, false)
+          },
+        )
+      }
+
+      const validatorSemantic = function (testStrings, expectedIssues) {
+        return validatorSemanticBase(
+          testStrings,
+          expectedIssues,
+          function (parsedTestString, schema) {
+            return hed.validateTopLevelTagGroups(parsedTestString, schema, true)
+          },
+        )
+      }
+
+      it('should not have definitions at the top level', () => {
+        const testStrings = {
+          validDefinition: '(Definition/SimpleDefinition)',
+          validDef: 'Def/TopLevelDefReference',
+          invalidDefinition: 'Definition/TopLevelDefinition',
+          invalidDouble: '(Definition/DoubleDefinition, Onset)',
+        }
+        const expectedIssues = {
+          validDefinition: [],
+          validDef: [],
+          invalidDefinition: [
+            generateIssue('invalidTopLevelTagGroupTag', {
+              tag: testStrings.invalidDefinition,
             }),
           ],
-          def: [],
+          invalidDouble: [
+            generateIssue('multipleTopLevelTagGroupTags', {
+              tag: 'Onset',
+              otherTag: 'Definition/DoubleDefinition',
+            }),
+          ],
         }
         return validatorSemantic(testStrings, expectedIssues)
       })

--- a/utils/hed.js
+++ b/utils/hed.js
@@ -10,6 +10,7 @@ const tagsDictionaryKey = 'tags'
 const takesValueType = 'takesValue'
 const unitClassType = 'unitClass'
 const unitClassUnitsType = 'units'
+const unitPrefixType = 'unitPrefix'
 const unitSymbolType = 'unitSymbol'
 const SIUnitKey = 'SIUnit'
 const SIUnitModifierKey = 'SIUnitModifier'
@@ -83,6 +84,21 @@ const validateValue = function (value, allowPlaceholders, isNumeric, isHed3) {
 }
 
 /**
+ * Determine whether a unit is a valid prefix unit.
+ *
+ * @param {string} unit A unit string.
+ * @param {SchemaAttributes} hedSchemaAttributes The collection of schema attributes.
+ * @return {boolean} Whether the unit is a valid prefix unit.
+ */
+const isPrefixUnit = function (unit, hedSchemaAttributes) {
+  if (unitPrefixType in hedSchemaAttributes.unitAttributes) {
+    return hedSchemaAttributes.unitAttributes[unitPrefixType][unit] || false
+  } else {
+    return unit === '$'
+  }
+}
+
+/**
  * Get the list of valid derivatives of a unit.
  *
  * @param {string} unit A unit string.
@@ -142,7 +158,10 @@ const validateUnits = function (
       hedSchemaAttributes.unitAttributes[unitSymbolType][unit] !== undefined
     const derivativeUnits = getValidDerivativeUnits(unit, hedSchemaAttributes)
     for (const derivativeUnit of derivativeUnits) {
-      if (originalTagUnitValue.startsWith(derivativeUnit)) {
+      if (
+        isPrefixUnit(unit, hedSchemaAttributes) &&
+        originalTagUnitValue.startsWith(derivativeUnit)
+      ) {
         foundUnit = true
         noUnitFound = false
         strippedValue = originalTagUnitValue
@@ -216,11 +235,15 @@ const getUnitClassDefaultUnit = function (formattedTag, hedSchemaAttributes) {
       )
     }
     if (hasDefaultAttribute) {
-      return hedSchemaAttributes.tagAttributes[defaultUnitForTagAttribute][unitClassTag]
+      return hedSchemaAttributes.tagAttributes[defaultUnitForTagAttribute][
+        unitClassTag
+      ]
     } else if (unitClassTag in hedSchemaAttributes.tagUnitClasses) {
       const unitClasses = hedSchemaAttributes.tagUnitClasses[unitClassTag]
       const firstUnitClass = unitClasses[0]
-      return hedSchemaAttributes.unitClassAttributes[firstUnitClass][defaultUnitsForUnitClassAttribute][0]
+      return hedSchemaAttributes.unitClassAttributes[firstUnitClass][
+        defaultUnitsForUnitClassAttribute
+      ][0]
     }
   } else {
     return ''

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -97,8 +97,14 @@ const generateIssue = function (code, parameters) {
     case 'multipleTagGroupsInDefinition':
       message = `ERROR: Multiple inner tag groups found in definition "${parameters.definition}"`
       break
-    case 'topLevelDefinitionTag':
-      message = `ERROR: Illegal top-level definition tag - "${parameters.tag}"`
+    case 'invalidTopLevelTagGroupTag':
+      message = `ERROR: Tag "${parameters.tag}" is only allowed inside of a top-level tag group.`
+      break
+    case 'multipleTopLevelTagGroupTags':
+      message = `ERROR: Tag "${parameters.tag}" found in top-level tag group where "${parameters.otherTag}" was already defined.`
+      break
+    case 'invalidTopLevelTag':
+      message = `ERROR: Illegal top-level tag - "${parameters.tag}"`
       break
     default:
       message = `ERROR: Unknown HED error.`

--- a/validator/stringParser.js
+++ b/validator/stringParser.js
@@ -93,6 +93,11 @@ const ParsedHedString = function (hedString) {
    * @type ParsedHedTag[]
    */
   this.topLevelTags = []
+  /**
+   * The top-level tag groups in the string, split into arrays.
+   * @type ParsedHedTag[][]
+   */
+  this.topLevelTagGroups = []
 }
 
 /**
@@ -214,9 +219,15 @@ const splitHedString = function (hedString, hedSchemas) {
  * @param {ParsedHedTag[]} groupTagsList The list of possible group tags.
  * @param {Schemas} hedSchemas The collection of HED schemas.
  * @param {ParsedHedString} parsedString The object to store parsed output in.
+ * @param {boolean} isTopLevel Whether these tag groups are at the top level.
  * @return {Issue[]} The array of issues.
  */
-const findTagGroups = function (groupTagsList, hedSchemas, parsedString) {
+const findTagGroups = function (
+  groupTagsList,
+  hedSchemas,
+  parsedString,
+  isTopLevel,
+) {
   let issues = []
   for (const tagOrGroup of groupTagsList) {
     if (hedStringIsAGroup(tagOrGroup.originalTag)) {
@@ -230,9 +241,13 @@ const findTagGroups = function (groupTagsList, hedSchemas, parsedString) {
         nestedGroupTagList,
         hedSchemas,
         parsedString,
+        false,
       )
       parsedString.tagGroupStrings.push(tagOrGroup)
       parsedString.tagGroups.push(nestedGroupTagList)
+      if (isTopLevel) {
+        parsedString.topLevelTagGroups.push(nestedGroupTagList)
+      }
       issues = issues.concat(nestedGroupIssues, nestedIssues)
     } else if (!parsedString.tags.includes(tagOrGroup)) {
       parsedString.tags.push(tagOrGroup)
@@ -317,7 +332,12 @@ const parseHedString = function (hedString, hedSchemas) {
     hedSchemas,
     parsedString,
   )
-  const tagGroupIssues = findTagGroups(hedTagList, hedSchemas, parsedString)
+  const tagGroupIssues = findTagGroups(
+    hedTagList,
+    hedSchemas,
+    parsedString,
+    true,
+  )
   formatHedTagsInList(parsedString.tags)
   formatHedTagsInList(parsedString.tagGroups)
   formatHedTagsInList(parsedString.topLevelTags)


### PR DESCRIPTION
This branch implements support for the `tagGroup`, `topLevelTagGroup`, and `unitPrefix` schema attributes.