### PR TITLE
Rewrite tag group parsing

### DIFF
--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -254,8 +254,7 @@ describe('HED string and event validation', () => {
 
       it('should substitute and warn for certain illegal characters', () => {
         const testStrings = {
-          nul:
-            '/Attribute/Object side/Left,/Participant/Effect/Body part/Arm\0',
+          nul: '/Attribute/Object side/Left,/Participant/Effect/Body part/Arm\0',
         }
         const expectedIssues = {
           nul: [
@@ -545,10 +544,14 @@ describe('HED string and event validation', () => {
             'Event/Category/Experimental stimulus,Event/Category/Experimental stimulus',
           groupDuplicate:
             'Item/Object/Vehicle/Train,(Event/Category/Experimental stimulus,Attribute/Visual/Color/Purple,Event/Category/Experimental stimulus)',
+          nestedGroupDuplicate:
+            'Item/Object/Vehicle/Train,(Attribute/Visual/Color/Purple,(Event/Category/Experimental stimulus,Event/Category/Experimental stimulus))',
           noDuplicate:
             'Event/Category/Experimental stimulus,Item/Object/Vehicle/Train,Attribute/Visual/Color/Purple',
           legalDuplicate:
             'Item/Object/Vehicle/Train,(Item/Object/Vehicle/Train,Event/Category/Experimental stimulus)',
+          nestedLegalDuplicate:
+            '(Item/Object/Vehicle/Train,(Item/Object/Vehicle/Train,Event/Category/Experimental stimulus))',
           legalDuplicateDifferentValue:
             '(Attribute/Language/Unit/Word/Brain,Attribute/Language/Unit/Word/Study)',
         }
@@ -556,15 +559,36 @@ describe('HED string and event validation', () => {
           topLevelDuplicate: [
             generateIssue('duplicateTag', {
               tag: 'Event/Category/Experimental stimulus',
+              bounds: [0, 36],
+            }),
+            generateIssue('duplicateTag', {
+              tag: 'Event/Category/Experimental stimulus',
+              bounds: [37, 73],
             }),
           ],
           groupDuplicate: [
             generateIssue('duplicateTag', {
               tag: 'Event/Category/Experimental stimulus',
+              bounds: [27, 63],
+            }),
+            generateIssue('duplicateTag', {
+              tag: 'Event/Category/Experimental stimulus',
+              bounds: [94, 130],
+            }),
+          ],
+          nestedGroupDuplicate: [
+            generateIssue('duplicateTag', {
+              tag: 'Event/Category/Experimental stimulus',
+              bounds: [58, 94],
+            }),
+            generateIssue('duplicateTag', {
+              tag: 'Event/Category/Experimental stimulus',
+              bounds: [95, 131],
             }),
           ],
           noDuplicate: [],
           legalDuplicate: [],
+          nestedLegalDuplicate: [],
           legalDuplicateDifferentValue: [],
         }
         validatorSyntactic(testStrings, expectedIssues)
@@ -955,11 +979,21 @@ describe('HED string and event validation', () => {
           duplicateSame: [
             generateIssue('duplicateTag', {
               tag: 'Train',
+              bounds: [0, 5],
+            }),
+            generateIssue('duplicateTag', {
+              tag: 'Train',
+              bounds: [6, 11],
             }),
           ],
           duplicateSimilar: [
             generateIssue('duplicateTag', {
-              tag: 'Item/Object/Man-made-object/Vehicle/Train',
+              tag: 'Train',
+              bounds: [0, 5],
+            }),
+            generateIssue('duplicateTag', {
+              tag: 'Vehicle/Train',
+              bounds: [6, 19],
             }),
           ],
           missingChild: [
@@ -1159,13 +1193,13 @@ describe('HED string and event validation', () => {
       })
     })
 
-    describe('HED Tag Levels', () => {
+    describe('HED Tag Groups', () => {
       const validatorSyntactic = function (testStrings, expectedIssues) {
         validatorSyntacticBase(
           testStrings,
           expectedIssues,
           function (parsedTestString) {
-            return hed.validateHedTagLevels(parsedTestString, {}, false)
+            return hed.validateHedTagGroups(parsedTestString, {}, false)
           },
         )
       }
@@ -1175,7 +1209,7 @@ describe('HED string and event validation', () => {
           testStrings,
           expectedIssues,
           function (parsedTestString, schema) {
-            return hed.validateHedTagLevels(parsedTestString, schema, true)
+            return hed.validateHedTagGroups(parsedTestString, schema, true)
           },
         )
       }

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -393,7 +393,7 @@ describe('HED string parsing', () => {
         '/Attribute/Location/Screen/Left/23 px',
       ])
       assert.sameDeepMembers(
-        parsedString.tagGroups.map((group) => group.map(originalMap)),
+        parsedString.tagGroups.map((group) => group.tags.map(originalMap)),
         [['/Attribute/Object side/Left', '/Participant/Effect/Body part/Arm']],
       )
     })

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -164,16 +164,19 @@ const generateIssue = function (internalCode, parameters) {
       message = `Multiple inner tag groups found in definition "${parameters.definition}"`
       break
     case 'invalidTopLevelTagGroupTag':
+      hedCode = 'HED_TAG_GROUP_ERROR'
       level = 'error'
       message = `Tag "${parameters.tag}" is only allowed inside of a top-level tag group.`
       break
     case 'multipleTopLevelTagGroupTags':
+      hedCode = 'HED_TAG_GROUP_ERROR'
       level = 'error'
       message = `Tag "${parameters.tag}" found in top-level tag group where "${parameters.otherTag}" was already defined.`
       break
     case 'invalidTopLevelTag':
+      hedCode = 'HED_TAG_GROUP_ERROR'
       level = 'error'
-      message = `Illegal top-level tag - "${parameters.tag}"`
+      message = `Tag "${parameters.tag}" is only allowed inside of a tag group.`
       break
     default:
       hedCode = 'HED_GENERIC_ERROR'

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -77,7 +77,7 @@ const generateIssue = function (internalCode, parameters) {
     case 'duplicateTag':
       hedCode = 'HED_TAG_REPEATED'
       level = 'error'
-      message = `Duplicate tag - "${parameters.tag}"`
+      message = `Duplicate tag at indices (${parameters.bounds[0]}, ${parameters.bounds[1]}) - "${parameters.tag}"`
       break
     case 'multipleUniqueTags':
       hedCode = 'HED_TAG_NOT_UNIQUE'


### PR DESCRIPTION
I've created a new type, `ParsedHedGroup`, to encapsulate tag group data. This allows us to iterate over the tags and nested inner tag groups more cleanly. The duplicate tag validation was completely rewritten, and it now displays errors for both duplicate tags. The issue with tag bounds within groups has been fixed, and all tags are now pegged to the full string. Additional tests have been added to ensure proper behavior.