### PR TITLE
Streamline issues

### DIFF
--- a/converter/issues.js
+++ b/converter/issues.js
@@ -1,4 +1,4 @@
-const issuesUtil = require('../utils/issues')
+const issuesUtil = require('../utils/issues/issues')
 
 /**
  * Generate an issue object for tag conversion.

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -1,7 +1,7 @@
 const assert = require('chai').assert
 const hed = require('../validator/dataset')
 const schema = require('../validator/schema')
-const generateValidationIssue = require('../utils/issues').generateIssue
+const generateValidationIssue = require('../utils/issues/issues').generateIssue
 const generateConverterIssue = require('../converter/issues')
 
 describe('HED dataset validation', () => {

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -2,7 +2,7 @@ const assert = require('chai').assert
 const hed = require('../validator/event')
 const schema = require('../validator/schema')
 const stringParser = require('../validator/stringParser')
-const generateIssue = require('../utils/issues').generateIssue
+const generateIssue = require('../utils/issues/issues').generateIssue
 const converterGenerateIssue = require('../converter/issues')
 const { Schemas } = require('../utils/schema')
 

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -9,7 +9,7 @@ const {
   removeGroupParentheses,
   splitHedString,
 } = require('../validator/stringParser')
-const generateIssue = require('../utils/issues').generateIssue
+const generateIssue = require('../utils/issues/issues').generateIssue
 
 describe('HED string parsing', () => {
   const nullSchema = new Schemas(null)

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,7 +4,7 @@ const HED = require('./hed')
 const array = require('./array')
 const files = require('./files')
 const string = require('./string')
-const issues = require('./issues')
+const issues = require('./issues/issues')
 
 // public api --------------------------------------------------------
 

--- a/utils/issueData.js
+++ b/utils/issueData.js
@@ -1,0 +1,151 @@
+const { stringTemplate } = require('./string')
+
+const issueData = {
+  parentheses: {
+    hedCode: 'HED_PARENTHESES_MISMATCH',
+    level: 'error',
+    message: stringTemplate`Number of opening and closing parentheses are unequal. ${'opening'} opening parentheses. ${'closing'} closing parentheses.`,
+  },
+  invalidTag: {
+    hedCode: 'HED_TAG_INVALID',
+    level: 'error',
+    message: stringTemplate`Invalid tag - "${'tag'}"`,
+  },
+  extraDelimiter: {
+    hedCode: 'HED_TAG_EMPTY',
+    level: 'error',
+    message: stringTemplate`Extra delimiter "${'character'}" at index ${'index'} of string "${'string'}"`,
+  },
+  commaMissing: {
+    hedCode: 'HED_COMMA MISSING',
+    level: 'error',
+    message: stringTemplate`Comma missing after - "${'tag'}"`,
+  },
+  capitalization: {
+    hedCode: 'HED_STYLE_WARNING',
+    level: 'warning',
+    message: stringTemplate`First word not capitalized or camel  - "${'tag'}"`,
+  },
+  duplicateTag: {
+    hedCode: 'HED_TAG_REPEATED',
+    level: 'error',
+    message: stringTemplate`Duplicate tag at indices (${0}, ${1}) - "${'tag'}"`,
+  },
+  multipleUniqueTags: {
+    hedCode: 'HED_TAG_NOT_UNIQUE',
+    level: 'error',
+    message: stringTemplate`Multiple unique tags with prefix - "${'tag'}"`,
+  },
+  tooManyTildes: {
+    hedCode: 'HED_TILDES_UNSUPPORTED',
+    level: 'error',
+    message: stringTemplate`Too many tildes - group "${'tagGroup'}"`,
+  },
+  childRequired: {
+    hedCode: 'HED_TAG_REQUIRES_CHILD',
+    level: 'error',
+    message: stringTemplate`Descendant tag required - "${'tag'}"`,
+  },
+  requiredPrefixMissing: {
+    hedCode: 'HED_REQUIRED_TAG_MISSING',
+    level: 'warning',
+    message: stringTemplate`Tag with prefix "${'tagPrefix'}" is required`,
+  },
+  unitClassDefaultUsed: {
+    hedCode: 'HED_UNITS_MISSING',
+    level: 'warning',
+    message: stringTemplate`No unit specified. Using "${'defaultUnit'}" as the default - "${'tag'}"`,
+  },
+  unitClassInvalidUnit: {
+    hedCode: 'HED_UNITS_INVALID',
+    level: 'error',
+    message: stringTemplate`Invalid unit - "${'tag'}" - valid units are "${'unitClassUnits'}"`,
+  },
+  extraCommaOrInvalid: {
+    hedCode: 'HED_TAG_INVALID',
+    level: 'error',
+    message: stringTemplate`Either "${'previousTag'}" contains a comma when it should not or "${'tag'}" is not a valid tag`,
+  },
+  invalidCharacter: {
+    hedCode: 'HED_CHARACTER_INVALID',
+    level: 'error',
+    message: stringTemplate`Invalid character "${'character'}" at index ${'index'} of string "${'string'}"`,
+  },
+  extension: {
+    hedCode: 'HED_TAG_EXTENDED',
+    level: 'warning',
+    message: stringTemplate`Tag extension found - "${'tag'}"`,
+  },
+  invalidPlaceholder: {
+    hedCode: 'HED_PLACEHOLDER_INVALID',
+    level: 'error',
+    message: stringTemplate`Invalid placeholder - "${'tag'}"`,
+  },
+  invalidPlaceholderInDefinition: {
+    hedCode: 'HED_PLACEHOLDER_INVALID',
+    level: 'error',
+    message: stringTemplate`Invalid placeholder in definition - "${'definition'}"`,
+  },
+  missingPlaceholder: {
+    hedCode: 'HED_PLACEHOLDER_INVALID',
+    level: 'error',
+    message: stringTemplate`HED value string "${'string'}" is missing a required placeholder.`,
+  },
+  invalidValue: {
+    hedCode: 'HED_VALUE_INVALID',
+    level: 'error',
+    message: stringTemplate`Invalid placeholder value for tag "${'tag'}"`,
+  },
+  invalidParentNode: {
+    hedCode: 'HED_VALUE_IS_NODE',
+    level: 'error',
+    message: stringTemplate`"${'tag'}" appears as "${'parentTag'}" and cannot be used as an extension. Indices (${0}, ${1}).`,
+  },
+  emptyTagFound: {
+    hedCode: 'HED_NODE_NAME_EMPTY',
+    level: 'error',
+    message: stringTemplate`Empty tag cannot be converted.`,
+  },
+  duplicateTagsInSchema: {
+    hedCode: 'HED_GENERIC_ERROR',
+    level: 'error',
+    message: stringTemplate`Source HED schema is invalid as it contains duplicate tags.`,
+  },
+  illegalDefinitionGroupTag: {
+    hedCode: 'HED_DEFINITION_INVALID',
+    level: 'error',
+    message: stringTemplate`Illegal tag "${'tag'}" in tag group for definition "${'definition'}"`,
+  },
+  nestedDefinition: {
+    hedCode: 'HED_DEFINITION_INVALID',
+    level: 'error',
+    message: stringTemplate`Illegal nested definition in tag group for definition "${'definition'}"`,
+  },
+  multipleTagGroupsInDefinition: {
+    hedCode: 'HED_DEFINITION_INVALID',
+    level: 'error',
+    message: stringTemplate`Multiple inner tag groups found in definition "${'definition'}"`,
+  },
+  invalidTopLevelTagGroupTag: {
+    hedCode: 'HED_TAG_GROUP_ERROR',
+    level: 'error',
+    message: stringTemplate`Tag "${'tag'}" is only allowed inside of a top-level tag group.`,
+  },
+  multipleTopLevelTagGroupTags: {
+    hedCode: 'HED_TAG_GROUP_ERROR',
+    level: 'error',
+    message: stringTemplate`Tag "${'tag'}" found in top-level tag group where "${'otherTag'}" was already defined.`,
+  },
+  invalidTopLevelTag: {
+    hedCode: 'HED_TAG_GROUP_ERROR',
+    level: 'error',
+    message: stringTemplate`Tag "${'tag'}" is only allowed inside of a tag group.`,
+  },
+  genericError: {
+    hedCode: 'HED_GENERIC_ERROR',
+    level: 'error',
+    message: stringTemplate`Unknown HED error.`,
+  },
+}
+
+module.exports = issueData

--- a/utils/issues.js
+++ b/utils/issues.js
@@ -1,3 +1,5 @@
+const issueData = require('./issueData')
+
 /**
  * A HED validation error or warning.
  *
@@ -45,157 +47,12 @@ const Issue = function (internalCode, hedCode, level, message) {
  * @return {Issue} An object representing the issue.
  */
 const generateIssue = function (internalCode, parameters) {
-  let message
-  let level = 'error'
-  let hedCode = 'HED_GENERIC_ERROR'
-  switch (internalCode) {
-    case 'parentheses':
-      hedCode = 'HED_PARENTHESES_MISMATCH'
-      level = 'error'
-      message = `Number of opening and closing parentheses are unequal. ${parameters.opening} opening parentheses. ${parameters.closing} closing parentheses.`
-      break
-    case 'invalidTag':
-      hedCode = 'HED_TAG_INVALID'
-      level = 'error'
-      message = `Invalid tag - "${parameters.tag}"`
-      break
-    case 'extraDelimiter':
-      hedCode = 'HED_TAG_EMPTY'
-      level = 'error'
-      message = `Extra delimiter "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
-      break
-    case 'commaMissing':
-      hedCode = 'HED_COMMA MISSING'
-      level = 'error'
-      message = `Comma missing after - "${parameters.tag}"`
-      break
-    case 'capitalization':
-      hedCode = 'HED_STYLE_WARNING'
-      level = 'warning'
-      message = `First word not capitalized or camel case - "${parameters.tag}"`
-      break
-    case 'duplicateTag':
-      hedCode = 'HED_TAG_REPEATED'
-      level = 'error'
-      message = `Duplicate tag at indices (${parameters.bounds[0]}, ${parameters.bounds[1]}) - "${parameters.tag}"`
-      break
-    case 'multipleUniqueTags':
-      hedCode = 'HED_TAG_NOT_UNIQUE'
-      level = 'error'
-      message = `Multiple unique tags with prefix - "${parameters.tag}"`
-      break
-    case 'tooManyTildes':
-      hedCode = 'HED_TILDES_UNSUPPORTED'
-      level = 'error'
-      message = `Too many tildes - group "${parameters.tagGroup}"`
-      break
-    case 'childRequired':
-      hedCode = 'HED_TAG_REQUIRES_CHILD'
-      level = 'error'
-      message = `Descendant tag required - "${parameters.tag}"`
-      break
-    case 'requiredPrefixMissing':
-      hedCode = 'HED_REQUIRED_TAG_MISSING'
-      level = 'warning'
-      message = `Tag with prefix "${parameters.tagPrefix}" is required`
-      break
-    case 'unitClassDefaultUsed':
-      hedCode = 'HED_UNITS_MISSING'
-      level = 'warning'
-      message = `No unit specified. Using "${parameters.defaultUnit}" as the default - "${parameters.tag}"`
-      break
-    case 'unitClassInvalidUnit':
-      hedCode = 'HED_UNITS_INVALID'
-      level = 'error'
-      message = `Invalid unit - "${parameters.tag}" - valid units are "${parameters.unitClassUnits}"`
-      break
-    case 'extraCommaOrInvalid':
-      hedCode = 'HED_TAG_INVALID'
-      level = 'error'
-      message = `Either "${parameters.previousTag}" contains a comma when it should not or "${parameters.tag}" is not a valid tag`
-      break
-    case 'invalidCharacter':
-      hedCode = 'HED_CHARACTER_INVALID'
-      level = 'error'
-      message = `Invalid character "${parameters.character}" at index ${parameters.index} of string "${parameters.string}"`
-      break
-    case 'extension':
-      hedCode = 'HED_TAG_EXTENDED'
-      level = 'warning'
-      message = `Tag extension found - "${parameters.tag}"`
-      break
-    case 'invalidPlaceholder':
-      hedCode = 'HED_PLACEHOLDER_INVALID'
-      level = 'error'
-      message = `Invalid placeholder - "${parameters.tag}"`
-      break
-    case 'invalidPlaceholderInDefinition':
-      hedCode = 'HED_PLACEHOLDER_INVALID'
-      level = 'error'
-      message = `Invalid placeholder in definition - "${parameters.definition}"`
-      break
-    case 'missingPlaceholder':
-      hedCode = 'HED_PLACEHOLDER_INVALID'
-      level = 'error'
-      message = `HED value string "${parameters.string}" is missing a required placeholder.`
-      break
-    case 'invalidValue':
-      hedCode = 'HED_VALUE_INVALID'
-      level = 'error'
-      message = `Invalid placeholder value for tag "${parameters.tag}"`
-      break
-    case 'invalidParentNode':
-      hedCode = 'HED_VALUE_IS_NODE'
-      level = 'error'
-      message = `"${parameters.tag}" appears as "${parameters.parentTag}" and cannot be used as an extension. Indices (${parameters.bounds[0]}, ${parameters.bounds[1]}).`
-      break
-    case 'emptyTagFound':
-      hedCode = 'HED_NODE_NAME_EMPTY'
-      level = 'error'
-      message = `Empty tag cannot be converted.`
-      break
-    case 'duplicateTagsInSchema':
-      level = 'error'
-      message = `Source HED schema is invalid as it contains duplicate tags.`
-      break
-    case 'illegalDefinitionGroupTag':
-      hedCode = 'HED_DEFINITION_INVALID'
-      level = 'error'
-      message = `Illegal tag "${parameters.tag}" in tag group for definition "${parameters.definition}"`
-      break
-    case 'nestedDefinition':
-      hedCode = 'HED_DEFINITION_INVALID'
-      level = 'error'
-      message = `Illegal nested definition in tag group for definition "${parameters.definition}"`
-      break
-    case 'multipleTagGroupsInDefinition':
-      hedCode = 'HED_DEFINITION_INVALID'
-      level = 'error'
-      message = `Multiple inner tag groups found in definition "${parameters.definition}"`
-      break
-    case 'invalidTopLevelTagGroupTag':
-      hedCode = 'HED_TAG_GROUP_ERROR'
-      level = 'error'
-      message = `Tag "${parameters.tag}" is only allowed inside of a top-level tag group.`
-      break
-    case 'multipleTopLevelTagGroupTags':
-      hedCode = 'HED_TAG_GROUP_ERROR'
-      level = 'error'
-      message = `Tag "${parameters.tag}" found in top-level tag group where "${parameters.otherTag}" was already defined.`
-      break
-    case 'invalidTopLevelTag':
-      hedCode = 'HED_TAG_GROUP_ERROR'
-      level = 'error'
-      message = `Tag "${parameters.tag}" is only allowed inside of a tag group.`
-      break
-    default:
-      hedCode = 'HED_GENERIC_ERROR'
-      level = 'error'
-      message = `Unknown HED error.`
-      break
-  }
+  const issueCodeData = issueData[internalCode] || issueData.genericError
+  const { hedCode, level, message } = issueCodeData
+  const bounds = parameters.bounds || []
+  const parsedMessage = message(...bounds, parameters)
 
-  return new Issue(internalCode, hedCode, level, message)
+  return new Issue(internalCode, hedCode, level, parsedMessage)
 }
 
 module.exports = {

--- a/utils/issues/data.js
+++ b/utils/issues/data.js
@@ -1,4 +1,4 @@
-const { stringTemplate } = require('./string')
+const { stringTemplate } = require('../string')
 
 const issueData = {
   parentheses: {

--- a/utils/issues/issues.js
+++ b/utils/issues/issues.js
@@ -1,4 +1,4 @@
-const issueData = require('./issueData')
+const issueData = require('./data')
 
 /**
  * A HED validation error or warning.

--- a/utils/string.js
+++ b/utils/string.js
@@ -69,6 +69,27 @@ const isNumber = function (numericString) {
   return digitExpression.test(numericString)
 }
 
+/**
+ * Parse a template literal string.
+ *
+ * Copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals.
+ *
+ * @param {string[]} strings The literal parts of the template string.
+ * @param {(number|string)} keys The keys of the closure arguments.
+ * @return {function(...[*]): string} A closure to fill the string template.
+ */
+const stringTemplate = function (strings, ...keys) {
+  return function (...values) {
+    let dict = values[values.length - 1] || {}
+    let result = [strings[0]]
+    keys.forEach(function (key, i) {
+      let value = Number.isInteger(key) ? values[key] : dict[key]
+      result.push(value, strings[i + 1])
+    })
+    return result.join('')
+  }
+}
+
 module.exports = {
   stringIsEmpty: stringIsEmpty,
   getCharacterCount: getCharacterCount,
@@ -76,4 +97,5 @@ module.exports = {
   isClockFaceTime: isClockFaceTime,
   isDateTime: isDateTime,
   isNumber: isNumber,
+  stringTemplate: stringTemplate,
 }

--- a/validator/event.js
+++ b/validator/event.js
@@ -6,7 +6,7 @@ const {
   ParsedHedTag,
   hedStringIsAGroup,
 } = require('./stringParser')
-const { generateIssue } = require('../utils/issues')
+const { generateIssue } = require('../utils/issues/issues')
 const { buildSchemaAttributesObject } = require('./schema')
 const { Schemas } = require('../utils/schema')
 const { convertHedStringToLong } = require('../converter/converter')


### PR DESCRIPTION
This PR streamlines the issue implementation by moving the data to a new module and using a template literal parser copied from MDN to simplify the interpolation stage. Both modules have been moved to a new folder.