### PR TITLE
Implement validation for non-event TSV files

### DIFF
--- a/bids/index.js
+++ b/bids/index.js
@@ -1,10 +1,20 @@
-import { BidsDataset, BidsEventFile, BidsHedIssue, BidsTsvFile, BidsIssue, BidsJsonFile, BidsSidecar } from './types'
+import {
+  BidsDataset,
+  BidsEventFile,
+  BidsTabularFile,
+  BidsHedIssue,
+  BidsTsvFile,
+  BidsIssue,
+  BidsJsonFile,
+  BidsSidecar,
+} from './types'
 import { validateBidsDataset } from './validate'
 
 export {
   BidsDataset,
   BidsTsvFile,
   BidsEventFile,
+  BidsTabularFile,
   BidsJsonFile,
   BidsSidecar,
   BidsIssue,
@@ -16,6 +26,7 @@ export default {
   BidsDataset,
   BidsTsvFile,
   BidsEventFile,
+  BidsTabularFile,
   BidsJsonFile,
   BidsSidecar,
   BidsIssue,

--- a/bids/tsvParser.js
+++ b/bids/tsvParser.js
@@ -1,0 +1,31 @@
+/**
+ * Module for parsing TSV files.
+ *
+ * Copied from https://github.com/bids-standard/bids-validator/blob/6fc6d152b52266934575442e61f1477ba18f42ec/bids-validator/validators/tsv/tsvParser.js
+ */
+
+const stripBOM = (str) => str.replace(/^\uFEFF/, '')
+const normalizeEOL = (str) => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+const isContentfulRow = (row) => row && !/^\s*$/.test(row)
+
+/**
+ * Parse a TSV file.
+ *
+ * @param {string} contents The contents of a TSV file.
+ * @return {{headers: string[], rows: string[][]}} The parsed contents of the TSV file.
+ */
+function parseTSV(contents) {
+  const content = {
+    headers: [],
+    rows: [],
+  }
+  contents = stripBOM(contents)
+  content.rows = normalizeEOL(contents)
+    .split('\n')
+    .filter(isContentfulRow)
+    .map((str) => str.split('\t'))
+  content.headers = content.rows.length ? content.rows[0] : []
+  return content
+}
+
+export default parseTSV

--- a/bids/types.js
+++ b/bids/types.js
@@ -1,5 +1,6 @@
 import { sidecarValueHasHed } from './utils'
 import { Issue } from '../common/issues/issues'
+import parseTSV from './tsvParser'
 
 /**
  * Base class for BIDS data.
@@ -78,7 +79,7 @@ export class BidsJsonFile extends BidsFile {
 export class BidsTsvFile extends BidsFile {
   /**
    * This file's parsed TSV data.
-   * @type {object}
+   * @type {{headers: string[], rows: string[][]}}
    */
   parsedTsv
   /**
@@ -108,14 +109,17 @@ export class BidsTsvFile extends BidsFile {
    * @todo This interface is provisional and subject to modification in version 4.0.0.
    *
    * @param {string} name The name of the TSV file.
-   * @param {object} parsedTsv This file's parsed TSV data.
+   * @param {{headers: string[], rows: string[][]}|string} tsvData This file's TSV data.
    * @param {object} file The file object representing this file.
    * @param {string[]} potentialSidecars The list of potential JSON sidecars.
    * @param {object} mergedDictionary The merged sidecar data.
    */
-  constructor(name, parsedTsv, file, potentialSidecars = [], mergedDictionary = {}) {
+  constructor(name, tsvData, file, potentialSidecars = [], mergedDictionary = {}) {
     super(name, file)
-    this.parsedTsv = parsedTsv
+    if (typeof tsvData === 'string') {
+      tsvData = parseTSV(tsvData)
+    }
+    this.parsedTsv = tsvData
     this.potentialSidecars = potentialSidecars
 
     this.mergedSidecar = new BidsSidecar(name, mergedDictionary, null)
@@ -148,11 +152,11 @@ export class BidsEventFile extends BidsTsvFile {
    * @param {string} name The name of the event TSV file.
    * @param {string[]} potentialSidecars The list of potential JSON sidecars.
    * @param {object} mergedDictionary The merged sidecar data.
-   * @param {object} parsedTsv This file's parsed TSV data.
+   * @param {{headers: string[], rows: string[][]}|string} tsvData This file's TSV data.
    * @param {object} file The file object representing this file.
    */
-  constructor(name, potentialSidecars, mergedDictionary, parsedTsv, file) {
-    super(name, parsedTsv, file, potentialSidecars, mergedDictionary)
+  constructor(name, potentialSidecars, mergedDictionary, tsvData, file) {
+    super(name, tsvData, file, potentialSidecars, mergedDictionary)
   }
 }
 
@@ -168,11 +172,11 @@ export class BidsTabularFile extends BidsTsvFile {
    * @param {string} name The name of the TSV file.
    * @param {string[]} potentialSidecars The list of potential JSON sidecars.
    * @param {object} mergedDictionary The merged sidecar data.
-   * @param {object} parsedTsv This file's parsed TSV data.
+   * @param {{headers: string[], rows: string[][]}|string} tsvData This file's TSV data.
    * @param {object} file The file object representing this file.
    */
-  constructor(name, potentialSidecars, mergedDictionary, parsedTsv, file) {
-    super(name, parsedTsv, file, potentialSidecars, mergedDictionary)
+  constructor(name, potentialSidecars, mergedDictionary, tsvData, file) {
+    super(name, tsvData, file, potentialSidecars, mergedDictionary)
   }
 }
 

--- a/bids/types.js
+++ b/bids/types.js
@@ -1,20 +1,27 @@
 import { sidecarValueHasHed } from './utils'
 import { Issue } from '../common/issues/issues'
 
+/**
+ * Base class for BIDS data.
+ * @deprecated Will be removed in v4.0.0.
+ */
 class BidsData {
   /**
    * A mapping from unparsed HED strings to ParsedHedString objects.
+   * @deprecated Will be removed in v4.0.0.
    * @type {Map<string, ParsedHedString>}
    */
   parsedStringMapping
   /**
    * A Mapping from definition names to their associated ParsedHedGroup objects.
+   * @deprecated Will be removed in v4.0.0.
    * @type {Map<string, ParsedHedGroup>}
    */
   definitions
   /**
    * A list of HED validation issues.
    * This will be converted to BidsIssue objects later on.
+   * @deprecated Will be removed in v4.0.0.
    * @type {Issue[]}
    */
   hedIssues
@@ -26,6 +33,9 @@ class BidsData {
   }
 }
 
+/**
+ * A BIDS file.
+ */
 class BidsFile extends BidsData {
   /**
    * The name of this file.
@@ -46,6 +56,9 @@ class BidsFile extends BidsData {
   }
 }
 
+/**
+ * A BIDS JSON file.
+ */
 export class BidsJsonFile extends BidsFile {
   /**
    * This file's JSON data.
@@ -59,6 +72,9 @@ export class BidsJsonFile extends BidsFile {
   }
 }
 
+/**
+ * A BIDS TSV file.
+ */
 export class BidsTsvFile extends BidsFile {
   /**
    * This file's parsed TSV data.
@@ -70,10 +86,40 @@ export class BidsTsvFile extends BidsFile {
    * @type {string[]}
    */
   hedColumnHedStrings
+  /**
+   * The list of potential JSON sidecars.
+   * @type {string[]}
+   */
+  potentialSidecars
+  /**
+   * The pseudo-sidecar object representing the merged sidecar data.
+   * @type {BidsSidecar}
+   */
+  mergedSidecar
+  /**
+   * The extracted HED data for the merged pseudo-sidecar.
+   * @type {Map<string, string|Object<string, string>>}
+   */
+  sidecarHedData
 
-  constructor(name, parsedTsv, file) {
+  /**
+   * Constructor.
+   *
+   * @todo This interface is provisional and subject to modification in version 4.0.0.
+   *
+   * @param {string} name The name of the TSV file.
+   * @param {object} parsedTsv This file's parsed TSV data.
+   * @param {object} file The file object representing this file.
+   * @param {string[]} potentialSidecars The list of potential JSON sidecars.
+   * @param {object} mergedDictionary The merged sidecar data.
+   */
+  constructor(name, parsedTsv, file, potentialSidecars = [], mergedDictionary = {}) {
     super(name, file)
     this.parsedTsv = parsedTsv
+    this.potentialSidecars = potentialSidecars
+
+    this.mergedSidecar = new BidsSidecar(name, mergedDictionary, null)
+    this.sidecarHedData = this.mergedSidecar.hedData
     this._parseHedColumn()
   }
 
@@ -90,29 +136,43 @@ export class BidsTsvFile extends BidsFile {
   }
 }
 
+/**
+ * A BIDS events.tsv file.
+ */
 export class BidsEventFile extends BidsTsvFile {
   /**
-   * The potential JSON sidecar data.
-   * @type {string[]}
+   * Constructor.
+   *
+   * @todo This interface is subject to modification in version 4.0.0.
+   *
+   * @param {string} name The name of the event TSV file.
+   * @param {string[]} potentialSidecars The list of potential JSON sidecars.
+   * @param {object} mergedDictionary The merged sidecar data.
+   * @param {object} parsedTsv This file's parsed TSV data.
+   * @param {object} file The file object representing this file.
    */
-  potentialSidecars
-  /**
-   * The pseudo-sidecar object representing the merged sidecar data.
-   * @type {BidsSidecar}
-   */
-  mergedSidecar
-  /**
-   * The extracted HED data for the merged pseudo-sidecar.
-   * @type {Map<string, string|Object<string, string>>}
-   */
-  sidecarHedData
-
   constructor(name, potentialSidecars, mergedDictionary, parsedTsv, file) {
-    super(name, parsedTsv, file)
-    this.potentialSidecars = potentialSidecars
+    super(name, parsedTsv, file, potentialSidecars, mergedDictionary)
+  }
+}
 
-    this.mergedSidecar = new BidsSidecar(name, mergedDictionary, null)
-    this.sidecarHedData = this.mergedSidecar.hedData
+/**
+ * A BIDS TSV file other than an events.tsv file.
+ */
+export class BidsTabularFile extends BidsTsvFile {
+  /**
+   * Constructor.
+   *
+   * @todo This interface is subject to modification in version 4.0.0.
+   *
+   * @param {string} name The name of the TSV file.
+   * @param {string[]} potentialSidecars The list of potential JSON sidecars.
+   * @param {object} mergedDictionary The merged sidecar data.
+   * @param {object} parsedTsv This file's parsed TSV data.
+   * @param {object} file The file object representing this file.
+   */
+  constructor(name, potentialSidecars, mergedDictionary, parsedTsv, file) {
+    super(name, parsedTsv, file, potentialSidecars, mergedDictionary)
   }
 }
 
@@ -133,6 +193,13 @@ export class BidsSidecar extends BidsJsonFile {
    */
   hedCategoricalStrings
 
+  /**
+   * Constructor.
+   *
+   * @param {string} name The name of the sidecar file.
+   * @param {Object} sidecarData The raw JSON data.
+   * @param {Object} file The file object representing this file.
+   */
   constructor(name, sidecarData = {}, file) {
     super(name, sidecarData, file)
 
@@ -182,7 +249,11 @@ export class BidsSidecar extends BidsJsonFile {
   }
 }
 
-// TODO: Remove in v4.0.0.
+/**
+ * Fallback default dataset_description.json file.
+ * @deprecated Will be removed in v4.0.0.
+ * @type {BidsJsonFile}
+ */
 const fallbackDatasetDescription = new BidsJsonFile('./dataset_description.json', null)
 
 export class BidsDataset extends BidsData {

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -383,13 +383,7 @@ describe('BIDS datasets', () => {
         '/sub03/sub03_task-test_run-1_events.tsv',
         ['/sub03/sub03_task-test_run-1_events.json'],
         sidecars[2][0],
-        {
-          headers: ['onset', 'duration'],
-          rows: [
-            ['onset', 'duration'],
-            ['7', 'something'],
-          ],
-        },
+        'onset\tduration\n' + '7\tsomething',
         {
           relativePath: '/sub03/sub03_task-test_run-1_events.tsv',
           path: '/sub03/sub03_task-test_run-1_events.tsv',
@@ -399,13 +393,7 @@ describe('BIDS datasets', () => {
         '/sub03/sub03_task-test_run-2_events.tsv',
         ['/sub01/sub01_task-test_run-1_events.json'],
         sidecars[0][0],
-        {
-          headers: ['onset', 'duration', 'color'],
-          rows: [
-            ['onset', 'duration', 'color'],
-            ['7', 'something', 'red'],
-          ],
-        },
+        'onset\tduration\tcolor\n' + '7\tsomething\tred',
         {
           relativePath: '/sub03/sub03_task-test_run-2_events.tsv',
           path: '/sub03/sub03_task-test_run-2_events.tsv',
@@ -415,13 +403,7 @@ describe('BIDS datasets', () => {
         '/sub03/sub03_task-test_run-3_events.tsv',
         ['/sub01/sub01_task-test_run-2_events.json'],
         sidecars[0][1],
-        {
-          headers: ['onset', 'duration', 'speed'],
-          rows: [
-            ['onset', 'duration', 'speed'],
-            ['7', 'something', '60'],
-          ],
-        },
+        'onset\tduration\tspeed\n' + '7\tsomething\t60',
         {
           relativePath: '/sub03/sub03_task-test_run-3_events.tsv',
           path: '/sub03/sub03_task-test_run-3_events.tsv',
@@ -444,13 +426,7 @@ describe('BIDS datasets', () => {
         '/sub03/sub03_task-test_run-5_events.tsv',
         ['/sub01/sub01_task-test_run-1_events.json'],
         sidecars[0][0],
-        {
-          headers: ['onset', 'duration', 'color', 'HED'],
-          rows: [
-            ['onset', 'duration', 'color', 'HED'],
-            ['7', 'something', 'green', 'Laptop-computer'],
-          ],
-        },
+        'onset\tduration\tcolor\tHED\n' + '7\tsomething\tgreen\tLaptop-computer',
         {
           relativePath: '/sub03/sub03_task-test_run-5_events.tsv',
           path: '/sub03/sub03_task-test_run-5_events.tsv',
@@ -460,13 +436,7 @@ describe('BIDS datasets', () => {
         '/sub03/sub03_task-test_run-6_events.tsv',
         ['/sub01/sub01_task-test_run-1_events.json', '/sub01/sub01_task-test_run-2_events.json'],
         Object.assign({}, sidecars[0][0], sidecars[0][1]),
-        {
-          headers: ['onset', 'duration', 'color', 'vehicle', 'speed'],
-          rows: [
-            ['onset', 'duration', 'color', 'vehicle', 'speed'],
-            ['7', 'something', 'blue', 'train', '150'],
-          ],
-        },
+        'onset\tduration\tcolor\tvehicle\tspeed\n' + '7\tsomething\tblue\ttrain\t150',
         {
           relativePath: '/sub03/sub03_task-test_run-6_events.tsv',
           path: '/sub03/sub03_task-test_run-6_events.tsv',
@@ -476,15 +446,10 @@ describe('BIDS datasets', () => {
         '/sub03/sub03_task-test_run-7_events.tsv',
         ['/sub01/sub01_task-test_run-1_events.json', '/sub01/sub01_task-test_run-2_events.json'],
         Object.assign({}, sidecars[0][0], sidecars[0][1]),
-        {
-          headers: ['onset', 'duration', 'color', 'vehicle', 'speed'],
-          rows: [
-            ['onset', 'duration', 'color', 'vehicle', 'speed'],
-            ['7', 'something', 'red', 'train', '150'],
-            ['11', 'else', 'blue', 'boat', '15'],
-            ['15', 'another', 'green', 'car', '70'],
-          ],
-        },
+        'onset\tduration\tcolor\tvehicle\tspeed\n' +
+          '7\tsomething\tred\ttrain\t150\n' +
+          '11\telse\tblue\tboat\t15\n' +
+          '15\tanother\tgreen\tcar\t70',
         {
           relativePath: '/sub03/sub03_task-test_run-7_events.tsv',
           path: '/sub03/sub03_task-test_run-7_events.tsv',
@@ -497,16 +462,11 @@ describe('BIDS datasets', () => {
         '/sub04/sub04_task-test_run-1_events.tsv',
         ['/sub02/sub02_task-test_run-2_events.json'],
         sidecars[1][1],
-        {
-          headers: ['onset', 'duration', 'emotion', 'HED'],
-          rows: [
-            ['onset', 'duration', 'emotion', 'HED'],
-            ['7', 'high', 'happy', 'Yellow'],
-            ['11', 'low', 'sad', 'Blue'],
-            ['15', 'mad', 'angry', 'Red'],
-            ['19', 'huh', 'confused', 'Gray'],
-          ],
-        },
+        'onset\tduration\temotion\tHED\n' +
+          '7\thigh\thappy\tYellow\n' +
+          '11\tlow\tsad\tBlue\n' +
+          '15\tmad\tangry\tRed\n' +
+          '19\thuh\tconfused\tGray',
         {
           relativePath: '/sub04/sub04_task-test_run-1_events.tsv',
           path: '/sub04/sub04_task-test_run-1_events.tsv',
@@ -516,16 +476,11 @@ describe('BIDS datasets', () => {
         '/sub04/sub04_task-test_run-2_events.tsv',
         ['/sub02/sub02_task-test_run-1_events.json'],
         sidecars[1][0],
-        {
-          headers: ['onset', 'duration', 'transport'],
-          rows: [
-            ['onset', 'duration', 'transport'],
-            ['7', 'wet', 'boat'],
-            ['11', 'steam', 'train'],
-            ['15', 'tires', 'car'],
-            ['19', 'speedy', 'maglev'],
-          ],
-        },
+        'onset\tduration\ttransport\n' +
+          '7\twet\tboat\n' +
+          '11\tsteam\ttrain\n' +
+          '15\ttires\tcar\n' +
+          '19\tspeedy\tmaglev',
         {
           relativePath: '/sub04/sub04_task-test_run-2_events.tsv',
           path: '/sub04/sub04_task-test_run-2_events.tsv',
@@ -535,16 +490,11 @@ describe('BIDS datasets', () => {
         '/sub04/sub04_task-test_run-3_events.tsv',
         ['/sub01/sub01_task-test_run-2_events.json', '/sub02/sub02_task-test_run-1_events.json'],
         Object.assign({}, sidecars[0][1], sidecars[1][0]),
-        {
-          headers: ['onset', 'duration', 'vehicle', 'transport', 'speed'],
-          rows: [
-            ['onset', 'duration', 'vehicle', 'transport', 'speed'],
-            ['7', 'ferry', 'train', 'boat', '20'],
-            ['11', 'autotrain', 'car', 'train', '79'],
-            ['15', 'towing', 'boat', 'car', '30'],
-            ['19', 'tugboat', 'boat', 'boat', '5'],
-          ],
-        },
+        'onset\tduration\tvehicle\ttransport\tspeed\n' +
+          '7\tferry\ttrain\tboat\t20\n' +
+          '11\tautotrain\tcar\ttrain\t79\n' +
+          '15\ttowing\tboat\tcar\t30\n' +
+          '19\ttugboat\tboat\tboat\t5',
         {
           relativePath: '/sub04/sub04_task-test_run-3_events.tsv',
           path: '/sub04/sub04_task-test_run-3_events.tsv',
@@ -554,13 +504,7 @@ describe('BIDS datasets', () => {
         '/sub04/sub04_task-test_run-4_events.tsv',
         ['/sub01/sub01_task-test_run-3_events.json'],
         sidecars[0][2],
-        {
-          headers: ['onset', 'duration', 'age', 'HED'],
-          rows: [
-            ['onset', 'duration', 'age', 'HED'],
-            ['7', 'ferry', '30', 'Age/30'],
-          ],
-        },
+        'onset\tduration\tage\tHED\n' + '7\tferry\t30\tAge/30',
         {
           relativePath: '/sub04/sub04_task-test_run-4_events.tsv',
           path: '/sub04/sub04_task-test_run-4_events.tsv',
@@ -570,13 +514,7 @@ describe('BIDS datasets', () => {
         '/sub04/sub04_task-test_run-5_events.tsv',
         ['/sub01/sub01_task-test_run-1_events.json'],
         sidecars[0][0],
-        {
-          headers: ['onset', 'duration', 'color'],
-          rows: [
-            ['onset', 'duration', 'color'],
-            ['7', 'royal', 'purple'],
-          ],
-        },
+        'onset\tduration\tcolor\n' + '7\troyal\tpurple',
         {
           relativePath: '/sub04/sub04_task-test_run-5_events.tsv',
           path: '/sub04/sub04_task-test_run-5_events.tsv',
@@ -589,13 +527,7 @@ describe('BIDS datasets', () => {
         '/sub05/sub05_task-test_run-1_events.tsv',
         ['/sub04/sub04_task-test_run-1_events.json'],
         sidecars[3][0],
-        {
-          headers: ['onset', 'duration', 'test', 'HED'],
-          rows: [
-            ['onset', 'duration', 'test', 'HED'],
-            ['7', 'something', 'first', 'Event/Duration/55 ms'],
-          ],
-        },
+        'onset\tduration\ttest\tHED\n' + '7\tsomething\tfirst\tEvent/Duration/55 ms',
         {
           relativePath: '/sub05/sub05_task-test_run-1_events.tsv',
           path: '/sub05/sub05_task-test_run-1_events.tsv',

--- a/validator/event/init.js
+++ b/validator/event/init.js
@@ -72,6 +72,7 @@ export const validateHedString = function (hedString, hedSchemas, ...args) {
     settings = {
       checkForWarnings: args[0] ?? false,
       expectValuePlaceholderString: args[1] ?? false,
+      definitionsAllowed: 'yes',
     }
   }
   const [parsedString, parsedStringIssues, hedValidator] = initiallyValidateHedString(hedString, hedSchemas, settings)


### PR DESCRIPTION
This will implement support for validating HED data in non-event BIDS data. It includes a new type (`BidsTabularFile`) and a restructuring of `BidsTsvFile`. `validateHedDataset` and `validateHedDatasetWithContext` now accept a settings object as the last argument.