### PR TITLE
Fix unescaped schema references and documentation in ParsedHedTag

### DIFF
--- a/parser/parsedHedTag.js
+++ b/parser/parsedHedTag.js
@@ -31,6 +31,7 @@ export class ParsedHedTag extends ParsedHedSubstring {
 
   /**
    * Constructor.
+   *
    * @param {string} originalTag The original HED tag.
    * @param {string} hedString The original HED string.
    * @param {number[]} originalBounds The bounds of the HED tag in the original HED string.
@@ -59,6 +60,15 @@ export class ParsedHedTag extends ParsedHedSubstring {
   }
 
   /**
+   * Nicely format this tag.
+   *
+   * @returns {string} The nicely formatted version of this tag.
+   */
+  format() {
+    return this.toString()
+  }
+
+  /**
    * Convert this tag to long form.
    *
    * @param {string} hedString The original HED string.
@@ -73,6 +83,8 @@ export class ParsedHedTag extends ParsedHedSubstring {
 
   /**
    * Format this HED tag by removing newlines, double quotes, and slashes.
+   *
+   * @returns {string} The formatted version of this tag.
    */
   _formatTag() {
     this.originalTag = this.originalTag.replace('\n', ' ')
@@ -92,12 +104,24 @@ export class ParsedHedTag extends ParsedHedSubstring {
     return hedTagString.toLowerCase()
   }
 
+  /**
+   * Determine whether this tag has a given attribute.
+   *
+   * @param {string} attribute An attribute name.
+   * @returns {boolean} Whether this tag has the named attribute.
+   */
   hasAttribute(attribute) {
-    return this.schema.tagHasAttribute(this.formattedTag, attribute)
+    return this.schema?.tagHasAttribute(this.formattedTag, attribute)
   }
 
+  /**
+   * Determine whether this tag's parent tag has a given attribute.
+   *
+   * @param {string} attribute An attribute name.
+   * @returns {boolean} Whether this tag's parent tag has the named attribute.
+   */
   parentHasAttribute(attribute) {
-    return this.schema.tagHasAttribute(this.parentFormattedTag, attribute)
+    return this.schema?.tagHasAttribute(this.parentFormattedTag, attribute)
   }
 
   /**
@@ -115,18 +139,33 @@ export class ParsedHedTag extends ParsedHedSubstring {
     }
   }
 
+  /**
+   * The trailing portion of {@link canonicalTag}.
+   *
+   * @returns {string} The "name" portion of the canonical tag.
+   */
   get canonicalTagName() {
     return this._memoize('canonicalTagName', () => {
       return ParsedHedTag.getTagName(this.canonicalTag)
     })
   }
 
+  /**
+   * The trailing portion of {@link formattedTag}.
+   *
+   * @returns {string} The "name" portion of the formatted tag.
+   */
   get formattedTagName() {
     return this._memoize('formattedTagName', () => {
       return ParsedHedTag.getTagName(this.formattedTag)
     })
   }
 
+  /**
+   * The trailing portion of {@link originalTag}.
+   *
+   * @returns {string} The "name" portion of the original tag.
+   */
   get originalTagName() {
     return this._memoize('originalTagName', () => {
       return ParsedHedTag.getTagName(this.originalTag)
@@ -135,6 +174,9 @@ export class ParsedHedTag extends ParsedHedSubstring {
 
   /**
    * Get the HED tag prefix (up to the last slash).
+   *
+   * @param {string} tagString A HED tag.
+   * @returns {string} The portion of the tag up to the last slash.
    */
   static getParentTag(tagString) {
     const lastSlashIndex = tagString.lastIndexOf('/')
@@ -145,18 +187,33 @@ export class ParsedHedTag extends ParsedHedSubstring {
     }
   }
 
+  /**
+   * The parent portion of {@link canonicalTag}.
+   *
+   * @returns {string} The "parent" portion of the canonical tag.
+   */
   get parentCanonicalTag() {
     return this._memoize('parentCanonicalTag', () => {
       return ParsedHedTag.getParentTag(this.canonicalTag)
     })
   }
 
+  /**
+   * The parent portion of {@link formattedTag}.
+   *
+   * @returns {string} The "parent" portion of the formatted tag.
+   */
   get parentFormattedTag() {
     return this._memoize('parentFormattedTag', () => {
       return ParsedHedTag.getParentTag(this.formattedTag)
     })
   }
 
+  /**
+   * The parent portion of {@link originalTag}.
+   *
+   * @returns {string} The "parent" portion of the original tag.
+   */
   get parentOriginalTag() {
     return this._memoize('parentOriginalTag', () => {
       return ParsedHedTag.getParentTag(this.originalTag)
@@ -167,7 +224,7 @@ export class ParsedHedTag extends ParsedHedSubstring {
    * Iterate through a tag's ancestor tag strings.
    *
    * @param {string} tagString A tag string.
-   * @yield {string} The tag's ancestor tags.
+   * @yields {string} The tag's ancestor tags.
    */
   static *ancestorIterator(tagString) {
     while (tagString.lastIndexOf('/') >= 0) {
@@ -181,7 +238,7 @@ export class ParsedHedTag extends ParsedHedSubstring {
    * Determine whether this tag is a descendant of another tag.
    *
    * @param {ParsedHedTag|string} parent The possible parent tag.
-   * @return {boolean} Whether {@code parent} is the parent tag of this tag.
+   * @returns {boolean} Whether {@link parent} is the parent tag of this tag.
    */
   isDescendantOf(parent) {
     if (parent instanceof ParsedHedTag) {
@@ -200,6 +257,8 @@ export class ParsedHedTag extends ParsedHedSubstring {
 
   /**
    * Check if any level of this HED tag allows extensions.
+   *
+   * @returns {boolean} Whether any level of this HED tag allows extensions.
    */
   get allowsExtensions() {
     return this._memoize('allowsExtensions', () => {
@@ -211,18 +270,26 @@ export class ParsedHedTag extends ParsedHedSubstring {
         return true
       }
       return getTagLevels(this.formattedTag).some((tagSubstring) =>
-        this.schema.tagHasAttribute(tagSubstring, extensionAllowedAttribute),
+        this.schema?.tagHasAttribute(tagSubstring, extensionAllowedAttribute),
       )
     })
   }
 
+  /**
+   * Determine if this HED tag is equivalent to another HED tag.
+   *
+   * HED tags are deemed equivalent if they have the same schema and formatted tag string.
+   *
+   * @param {ParsedHedTag} other A HED tag.
+   * @returns {boolean} Whether {@link other} is equivalent to this HED tag.
+   */
   equivalent(other) {
     return other instanceof ParsedHedTag && this.formattedTag === other.formattedTag && this.schema === other.schema
   }
 }
 
 /**
- * A parsed HED3 tag.
+ * A parsed HED-3G tag.
  */
 export class ParsedHed3Tag extends ParsedHedTag {
   /**
@@ -277,10 +344,10 @@ export class ParsedHed3Tag extends ParsedHedTag {
   /**
    * Nicely format this tag.
    *
-   * @returns {string}
+   * @returns {string} The nicely formatted version of this tag.
    */
   format() {
-    let tagName = this.schema.entries.definitions.get('tags').getEntry(this.formattedTag)?.name
+    let tagName = this.schema?.entries.definitions.get('tags').getEntry(this.formattedTag)?.name
     if (tagName === undefined) {
       tagName = this.originalTag
     }
@@ -292,23 +359,27 @@ export class ParsedHed3Tag extends ParsedHedTag {
   }
 
   /**
-   * Determine if this HED tag is in the schema.
+   * Determine if this HED tag is in the linked schema.
+   *
+   * @returns {boolean} Whether this HED tag is in the linked schema.
    */
   get existsInSchema() {
     return this._memoize('existsInSchema', () => {
-      return this.schema.entries.definitions.get('tags').hasEntry(this.formattedTag)
+      return this.schema?.entries.definitions.get('tags').hasEntry(this.formattedTag)
     })
   }
 
   /**
-   * Determine value-taking form of this tag.
+   * Get the value-taking form of this tag.
+   *
+   * @returns {string} The value-taking form of this tag.
    */
   get takesValueFormattedTag() {
     return this._memoize('takesValueFormattedTag', () => {
       const takesValueType = 'takesValue'
       for (const ancestor of ParsedHedTag.ancestorIterator(this.formattedTag)) {
         const takesValueTag = replaceTagNameWithPound(ancestor)
-        if (this.schema.tagHasAttribute(takesValueTag, takesValueType)) {
+        if (this.schema?.tagHasAttribute(takesValueTag, takesValueType)) {
           return takesValueTag
         }
       }
@@ -317,7 +388,24 @@ export class ParsedHed3Tag extends ParsedHedTag {
   }
 
   /**
-   * Checks if this HED tag has the 'takesValue' attribute.
+   * Get the schema tag object for this tag's value-taking form.
+   *
+   * @returns {SchemaTag} The schema tag object for this tag's value-taking form.
+   */
+  get takesValueTag() {
+    return this._memoize('takesValueTag', () => {
+      if (this.takesValueFormattedTag !== null) {
+        return this.schema?.entries.definitions.get('tags').getEntry(this.takesValueFormattedTag)
+      } else {
+        return null
+      }
+    })
+  }
+
+  /**
+   * Checks if this HED tag has the {@code takesValue} attribute.
+   *
+   * @returns {boolean} Whether this HED tag has the {@code takesValue} attribute.
    */
   get takesValue() {
     return this._memoize('takesValue', () => {
@@ -326,11 +414,13 @@ export class ParsedHed3Tag extends ParsedHedTag {
   }
 
   /**
-   * Checks if this HED tag has the 'unitClass' attribute.
+   * Checks if this HED tag has the {@code unitClass} attribute.
+   *
+   * @returns {boolean} Whether this HED tag has the {@code unitClass} attribute.
    */
   get hasUnitClass() {
     return this._memoize('hasUnitClass', () => {
-      if (!this.schema.entries.definitions.has('unitClasses')) {
+      if (!this.schema?.entries.definitions.has('unitClasses')) {
         return false
       }
       if (this.takesValueTag === null) {
@@ -342,6 +432,8 @@ export class ParsedHed3Tag extends ParsedHedTag {
 
   /**
    * Get the unit classes for this HED tag.
+   *
+   * @returns {SchemaUnitClass[]} The unit classes for this HED tag.
    */
   get unitClasses() {
     return this._memoize('unitClasses', () => {
@@ -355,6 +447,8 @@ export class ParsedHed3Tag extends ParsedHedTag {
 
   /**
    * Get the default unit for this HED tag.
+   *
+   * @returns {string} The default unit for this HED tag.
    */
   get defaultUnit() {
     return this._memoize('defaultUnit', () => {
@@ -372,35 +466,21 @@ export class ParsedHed3Tag extends ParsedHedTag {
   }
 
   /**
-   * Get the legal units for a particular HED tag.
-   * @returns {Set<SchemaUnit>}
+   * Get the legal units for this HED tag.
+   *
+   * @returns {Set<SchemaUnit>} The legal units for this HED tag.
    */
   get validUnits() {
     return this._memoize('validUnits', () => {
       const tagUnitClasses = this.unitClasses
       const units = new Set()
       for (const unitClass of tagUnitClasses) {
-        const unitClassUnits = this.schema.entries.unitClassMap.getEntry(unitClass.name).units
+        const unitClassUnits = this.schema?.entries.unitClassMap.getEntry(unitClass.name).units
         for (const unit of unitClassUnits.values()) {
           units.add(unit)
         }
       }
       return units
-    })
-  }
-
-  /**
-   * Get the schema tag object for this tag's value-taking form.
-   *
-   * @returns {SchemaTag}
-   */
-  get takesValueTag() {
-    return this._memoize('takesValueTag', () => {
-      if (this.takesValueFormattedTag !== null) {
-        return this.schema.entries.definitions.get('tags').getEntry(this.takesValueFormattedTag)
-      } else {
-        return null
-      }
     })
   }
 }


### PR DESCRIPTION
This PR adds complete optional chaining for schema references in `ParsedHedTag`. I also rewrote documentation in that module.

Fixes #128