### PR TITLE
Make TSV validation event-based

### DIFF
--- a/bids/types/tsv.js
+++ b/bids/types/tsv.js
@@ -132,6 +132,9 @@ export class BidsTabularFile extends BidsTsvFile {
   }
 }
 
+/**
+ * A row in a BIDS TSV file.
+ */
 export class BidsTsvRow extends ParsedHedString {
   /**
    * The parsed string representing this row.
@@ -156,6 +159,7 @@ export class BidsTsvRow extends ParsedHedString {
 
   /**
    * Constructor.
+   *
    * @param {ParsedHedString} parsedString The parsed string representing this row.
    * @param {Map<string, string>} rowCells The column-to-value mapping for this row.
    * @param {BidsTsvFile} tsvFile The file this row belongs to.
@@ -177,5 +181,64 @@ export class BidsTsvRow extends ParsedHedString {
    */
   toString() {
     return super.toString() + ` in TSV file "${this.tsvFile.name}" at line ${this.tsvLine}`
+  }
+
+  /**
+   * The onset of this row.
+   *
+   * @return {number} The onset of this row.
+   */
+  get onset() {
+    const value = Number(this.rowCells.get('onset'))
+    if (Number.isNaN(value)) {
+      throw new Error('Attempting to access the onset of a TSV row without one.')
+    }
+    return value
+  }
+}
+
+/**
+ * An event in a BIDS TSV file.
+ */
+export class BidsTsvEvent extends ParsedHedString {
+  /**
+   * The file this row belongs to.
+   * @type {BidsTsvFile}
+   */
+  tsvFile
+  /**
+   * The TSV rows making up this event.
+   * @type {BidsTsvRow[]}
+   */
+  tsvRows
+
+  /**
+   * Constructor.
+   *
+   * @param {BidsTsvFile} tsvFile The file this row belongs to.
+   * @param {BidsTsvRow[]} tsvRows The TSV rows making up this event.
+   */
+  constructor(tsvFile, tsvRows) {
+    super(tsvRows.map((tsvRow) => tsvRow.hedString).join(', '), tsvRows.map((tsvRow) => tsvRow.parseTree).flat())
+    this.tsvFile = tsvFile
+    this.tsvRows = tsvRows
+  }
+
+  /**
+   * The lines in the TSV file corresponding to this event.
+   *
+   * @return {string} The lines in the TSV file corresponding to this event.
+   */
+  get tsvLines() {
+    return this.tsvRows.map((tsvRow) => tsvRow.tsvLine).join(', ')
+  }
+
+  /**
+   * Override of {@link Object.prototype.toString}.
+   *
+   * @returns {string}
+   */
+  toString() {
+    return super.toString() + ` in TSV file "${this.tsvFile.name}" at line(s) ${this.tsvLines}`
   }
 }

--- a/utils/map.js
+++ b/utils/map.js
@@ -1,3 +1,4 @@
+import identity from 'lodash/identity'
 import isEqual from 'lodash/isEqual'
 
 /**
@@ -26,4 +27,25 @@ export const filterNonEqualDuplicates = function (list, equalityFunction = isEqu
     duplicates.push([key, value])
   }
   return [map, duplicates]
+}
+
+/**
+ * Group a list by a given grouping function.
+ *
+ * @template T, U
+ * @param {T[]} list The list to group.
+ * @param {function (T): U} groupingFunction A function mapping a list value to the key it is to be grouped under.
+ * @return {Map<U, T[]>} The grouped map.
+ */
+export const groupBy = function (list, groupingFunction = identity) {
+  const groupingMap = new Map()
+  for (const listEntry of list) {
+    const groupingValue = groupingFunction(listEntry)
+    if (groupingMap.has(groupingValue)) {
+      groupingMap.get(groupingValue).push(listEntry)
+    } else {
+      groupingMap.set(groupingValue, [listEntry])
+    }
+  }
+  return groupingMap
 }


### PR DESCRIPTION
This PR merges TSV rows with the same onset into a single `BidsTsvEvent` object (for timeline TSV files only) and sorts them by their onset value.