### PR TITLE
[WIP] Add TSV line numbers to TSV-related issue messages

### DIFF
--- a/common/issues/issues.js
+++ b/common/issues/issues.js
@@ -76,8 +76,7 @@ export class Issue {
     this.code = internalCode
     this.hedCode = hedCode
     this.level = level
-    // Pre-convert all parameters except the substring bounds (an integer array) to their string forms.
-    this.parameters = mapValues(parameters, (value, key) => (key === 'bounds' ? value : String(value)))
+    this.parameters = parameters
     this.generateMessage()
   }
 
@@ -94,9 +93,14 @@ export class Issue {
    * (Re-)generate the issue message.
    */
   generateMessage() {
+    // Convert all parameters except the substring bounds (an integer array) to their string forms.
+    this.parameters = mapValues(this.parameters, (value, key) => (key === 'bounds' ? value : String(value)))
+
     const bounds = this.parameters.bounds ?? []
     const messageTemplate = issueData[this.internalCode].message
     let message = messageTemplate(...bounds, this.parameters)
+
+    // Special parameters
     if (this.parameters.sidecarKey) {
       message += ` Sidecar key: "${this.parameters.sidecarKey}".`
     }
@@ -106,8 +110,11 @@ export class Issue {
     if (this.parameters.hedString) {
       message += ` HED string: "${this.parameters.hedString}".`
     }
+
+    // Append link to error code in HED spec.
     const hedCodeAnchor = this.hedCode.toLowerCase().replace(/_/g, '-')
     const hedSpecLink = `For more information on this HED ${this.level}, see https://hed-specification.readthedocs.io/en/latest/Appendix_B.html#${hedCodeAnchor}`
+
     this.message = `${this.level.toUpperCase()}: [${this.hedCode}] ${message} (${hedSpecLink}.)`
   }
 

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -482,7 +482,7 @@ describe('BIDS datasets', () => {
       const expectedIssues = {
         bad_tsv: [
           BidsHedIssue.fromHedIssue(
-            generateIssue('illegalDefinitionContext', { string: '(Definition/myDef, (Label/Red, Green))' }),
+            generateIssue('illegalDefinitionContext', { string: '(Definition/myDef, (Label/Red, Green))', tsvLine: 2 }),
             badTsvDatasets[0].file,
           ),
         ],

--- a/validator/event/validator.js
+++ b/validator/event/validator.js
@@ -267,6 +267,10 @@ export class HedValidator {
    * @param {Object<string, (string|number[])>} parameters The error string parameters.
    */
   pushIssue(internalCode, parameters) {
+    const tsvLine = this.parsedString.tsvLine ?? this.parsedString.tsvLines
+    if (tsvLine) {
+      parameters.tsvLine = tsvLine
+    }
     this.issues.push(generateIssue(internalCode, parameters))
   }
 }


### PR DESCRIPTION
This PR will eventually add line numbers for issues related to BIDS TSV files to their respectively generated issue messages and objects. They will be pulled from either the `BidsTsvEvent`/`BidsTsvRow` object or injected during `HED` column validation.

Fixes #59