### PR TITLE
Add dataset_description.json as file for certain internal errors

### DIFF
--- a/bids/types/issues.js
+++ b/bids/types/issues.js
@@ -44,8 +44,8 @@ export class BidsIssue {
     return issues.some((issue) => issue.isError())
   }
 
-  static generateInternalErrorPromise(error) {
-    return Promise.resolve([new BidsIssue(106, null, error.message)])
+  static generateInternalErrorPromise(error, errorFile) {
+    return Promise.resolve([new BidsIssue(106, errorFile, error.message)])
   }
 }
 

--- a/bids/validate.js
+++ b/bids/validate.js
@@ -18,7 +18,7 @@ export async function validateBidsDataset(dataset, schemaDefinition) {
     try {
       return validator.validateFullDataset()
     } catch (internalError) {
-      return BidsIssue.generateInternalErrorPromise(internalError)
+      return BidsIssue.generateInternalErrorPromise(internalError, dataset.datasetDescription.file)
     }
   } catch (schemaIssues) {
     return BidsHedIssue.fromHedIssues(schemaIssues, dataset.datasetDescription.file)


### PR DESCRIPTION
This simple PR adds `dataset_description.json` as the file for certain internal errors when validating BIDS datasets.