### PR TITLE
Replace remaining possible uses of promises with async/await

### DIFF
--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -10,13 +10,13 @@ import { SchemaSpec, SchemasSpec } from '../common/schema/types'
 describe('HED dataset validation', () => {
   const hedSchemaFile = 'tests/data/HED8.2.0.xml'
   const hedLibrarySchemaFile = 'tests/data/HED_testlib_2.0.0.xml'
-  let hedSchemaPromise
+  let hedSchemas
 
-  beforeAll(() => {
+  beforeAll(async () => {
     const spec1 = new SchemaSpec('', '8.2.0', '', hedSchemaFile)
     const spec2 = new SchemaSpec('testlib', '2.0.0', 'testlib', hedLibrarySchemaFile)
     const specs = new SchemasSpec().addSchemaSpec(spec1).addSchemaSpec(spec2)
-    hedSchemaPromise = buildSchemas(specs)
+    hedSchemas = await buildSchemas(specs)
   })
 
   describe('Basic HED string lists', () => {
@@ -27,7 +27,6 @@ describe('HED dataset validation', () => {
      * @param {Object<string, Issue[]>} expectedIssues The expected issues.
      */
     const validator = async function (testDatasets, expectedIssues) {
-      const hedSchemas = await hedSchemaPromise
       for (const [testDatasetKey, testDataset] of Object.entries(testDatasets)) {
         assert.property(expectedIssues, testDatasetKey, testDatasetKey + ' is not in expectedIssues')
         const [, testIssues] = hed.validateHedEvents(testDataset, hedSchemas, null, true)
@@ -81,7 +80,6 @@ describe('HED dataset validation', () => {
      * @param {Object<string, Issue[]>} expectedIssues The expected issues.
      */
     const validator = async function (testDatasets, expectedIssues) {
-      const hedSchemas = await hedSchemaPromise
       for (const [testDatasetKey, testDataset] of Object.entries(testDatasets)) {
         assert.property(expectedIssues, testDatasetKey, testDatasetKey + ' is not in expectedIssues')
         const [, testIssues] = hed.validateHedDataset(testDataset, hedSchemas, true)
@@ -218,7 +216,6 @@ describe('HED dataset validation', () => {
      * @param {Object<string, Issue[]>} expectedIssues The expected issues.
      */
     const validator = async function (testDatasets, testContext, expectedIssues) {
-      const hedSchemas = await hedSchemaPromise
       for (const [testDatasetKey, testDataset] of Object.entries(testDatasets)) {
         assert.property(expectedIssues, testDatasetKey, testDatasetKey + ' is not in expectedIssues')
         const [, testIssues] = hed.validateHedDatasetWithContext(testDataset, testContext, hedSchemas, true)

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -338,12 +338,12 @@ describe('HED string and event validation', () => {
   describe('HED-2G validation', () => {
     describe('Later HED-2G schemas', () => {
       const hedSchemaFile = 'tests/data/HED7.1.1.xml'
-      let hedSchemaPromise
+      let hedSchemas
 
-      beforeAll(() => {
+      beforeAll(async () => {
         const spec1 = new SchemaSpec('', '7.1.1', '', hedSchemaFile)
         const specs = new SchemasSpec().addSchemaSpec(spec1)
-        hedSchemaPromise = buildSchemas(specs)
+        hedSchemas = await buildSchemas(specs)
       })
 
       /**
@@ -357,9 +357,7 @@ describe('HED string and event validation', () => {
        * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
        */
       const validatorSemanticBase = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
-        return hedSchemaPromise.then((hedSchemas) => {
-          validatorBase(hedSchemas, Hed2Validator, testStrings, expectedIssues, testFunction, testOptions)
-        })
+        validatorBase(hedSchemas, Hed2Validator, testStrings, expectedIssues, testFunction, testOptions)
       }
 
       describe('Full HED Strings', () => {
@@ -686,13 +684,11 @@ describe('HED string and event validation', () => {
 
       describe('HED Strings', () => {
         const validator = function (testStrings, expectedIssues, expectValuePlaceholderString = false) {
-          return hedSchemaPromise.then((hedSchemas) => {
-            for (const [testStringKey, testString] of Object.entries(testStrings)) {
-              assert.property(expectedIssues, testStringKey, testStringKey + ' is not in expectedIssues')
-              const [, testIssues] = hed.validateHedString(testString, hedSchemas, true, expectValuePlaceholderString)
-              assert.sameDeepMembers(testIssues, expectedIssues[testStringKey], testString)
-            }
-          })
+          for (const [testStringKey, testString] of Object.entries(testStrings)) {
+            assert.property(expectedIssues, testStringKey, testStringKey + ' is not in expectedIssues')
+            const [, testIssues] = hed.validateHedString(testString, hedSchemas, true, expectValuePlaceholderString)
+            assert.sameDeepMembers(testIssues, expectedIssues[testStringKey], testString)
+          }
         }
 
         it('should skip tag group-level checks', () => {
@@ -711,12 +707,12 @@ describe('HED string and event validation', () => {
 
     describe('Pre-v7.1.0 HED schemas', () => {
       const hedSchemaFile = 'tests/data/HED7.0.4.xml'
-      let hedSchemaPromise
+      let hedSchemas
 
-      beforeAll(() => {
+      beforeAll(async () => {
         const spec2 = new SchemaSpec('', '7.0.4', '', hedSchemaFile)
         const specs = new SchemasSpec().addSchemaSpec(spec2)
-        hedSchemaPromise = buildSchemas(specs)
+        hedSchemas = await buildSchemas(specs)
       })
 
       /**
@@ -730,9 +726,7 @@ describe('HED string and event validation', () => {
        * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
        */
       const validatorSemanticBase = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
-        return hedSchemaPromise.then((hedSchemas) => {
-          validatorBase(hedSchemas, Hed2Validator, testStrings, expectedIssues, testFunction, testOptions)
-        })
+        validatorBase(hedSchemas, Hed2Validator, testStrings, expectedIssues, testFunction, testOptions)
       }
 
       describe('Individual HED Tags', () => {
@@ -850,12 +844,12 @@ describe('HED string and event validation', () => {
 
   describe('HED-3G validation', () => {
     const hedSchemaFile = 'tests/data/HED8.2.0.xml'
-    let hedSchemaPromise
+    let hedSchemas
 
-    beforeAll(() => {
+    beforeAll(async () => {
       const spec3 = new SchemaSpec('', '8.2.0', '', hedSchemaFile)
       const specs = new SchemasSpec().addSchemaSpec(spec3)
-      hedSchemaPromise = buildSchemas(specs)
+      hedSchemas = await buildSchemas(specs)
     })
 
     /**
@@ -894,9 +888,7 @@ describe('HED string and event validation', () => {
      * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
      */
     const validatorSemanticBase = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
-      return hedSchemaPromise.then((hedSchemas) => {
-        validatorBase(hedSchemas, testStrings, expectedIssues, testFunction, testOptions)
-      })
+      validatorBase(hedSchemas, testStrings, expectedIssues, testFunction, testOptions)
     }
 
     describe('Full HED Strings', () => {
@@ -1762,10 +1754,8 @@ describe('HED string and event validation', () => {
             generateIssue('invalidPlaceholder', { tag: 'Time-value/#' }),
           ],
         }
-        return Promise.all([
-          validatorSemantic(expectedPlaceholdersTestStrings, expectedPlaceholdersIssues, true),
-          validatorSemantic(noExpectedPlaceholdersTestStrings, noExpectedPlaceholdersIssues, false),
-        ])
+        validatorSemantic(expectedPlaceholdersTestStrings, expectedPlaceholdersIssues, true)
+        validatorSemantic(noExpectedPlaceholdersTestStrings, noExpectedPlaceholdersIssues, false)
       })
     })
   })
@@ -1773,17 +1763,17 @@ describe('HED string and event validation', () => {
   describe('HED-3G library and partnered schema validation', () => {
     const hedLibrary2SchemaFile = 'tests/data/HED_testlib_2.0.0.xml'
     const hedLibrary3SchemaFile = 'tests/data/HED_testlib_3.0.0.xml'
-    let hedSchemaPromise, hedSchemaPromise2
+    let hedSchemas, hedSchemas2
 
-    beforeAll(() => {
+    beforeAll(async () => {
       const spec4 = new SchemaSpec('testlib', '2.0.0', 'testlib', hedLibrary2SchemaFile)
       const spec5 = new SchemaSpec('testlib', '3.0.0', 'testlib', hedLibrary3SchemaFile)
       const spec6 = new SchemaSpec('', '2.0.0', 'testlib', hedLibrary2SchemaFile)
       const spec7 = new SchemaSpec('', '3.0.0', 'testlib', hedLibrary3SchemaFile)
       const specs = new SchemasSpec().addSchemaSpec(spec4).addSchemaSpec(spec5)
       const specs2 = new SchemasSpec().addSchemaSpec(spec6).addSchemaSpec(spec7)
-      hedSchemaPromise = buildSchemas(specs)
-      hedSchemaPromise2 = buildSchemas(specs2)
+      hedSchemas = await buildSchemas(specs)
+      hedSchemas2 = await buildSchemas(specs2)
     })
 
     /**
@@ -1822,16 +1812,14 @@ describe('HED string and event validation', () => {
      * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
      */
     const validatorSemanticBase = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
-      return hedSchemaPromise.then((hedSchemas) => {
-        validatorBase(hedSchemas, testStrings, expectedIssues, testFunction, testOptions)
-      })
+      validatorBase(hedSchemas, testStrings, expectedIssues, testFunction, testOptions)
     }
 
     describe('Full HED Strings', () => {
       const validatorSemantic = validatorSemanticBase
 
       /**
-       * HED 3 semantic validation function using the alternate schema Promise object.
+       * HED 3 semantic validation function using the alternative schema collection.
        *
        * This base function uses the HED 3-specific {@link Hed3Validator} validator class.
        *
@@ -1841,9 +1829,7 @@ describe('HED string and event validation', () => {
        * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
        */
       const validatorSemantic2 = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
-        return hedSchemaPromise2.then((hedSchemas) => {
-          validatorBase(hedSchemas, testStrings, expectedIssues, testFunction, testOptions)
-        })
+        validatorBase(hedSchemas2, testStrings, expectedIssues, testFunction, testOptions)
       }
 
       it('should allow combining tags from multiple partnered schemas', () => {

--- a/tests/schema.spec.js
+++ b/tests/schema.spec.js
@@ -116,15 +116,15 @@ describe('HED schemas', () => {
 
   describe('HED-2G schemas', () => {
     const localHedSchemaFile = 'tests/data/HED7.1.1.xml'
-    let hedSchemaPromise
+    let hedSchemas
 
-    beforeAll(() => {
+    beforeAll(async () => {
       const spec1 = new SchemaSpec('', '7.1.1', '', localHedSchemaFile)
       const specs = new SchemasSpec().addSchemaSpec(spec1)
-      hedSchemaPromise = buildSchemas(specs)
+      hedSchemas = await buildSchemas(specs)
     })
 
-    it('should have tag dictionaries for all required tag attributes', async () => {
+    it('should have tag dictionaries for all required tag attributes', () => {
       const tagDictionaryKeys = [
         'default',
         'extensionAllowed',
@@ -137,41 +137,35 @@ describe('HED schemas', () => {
         'takesValue',
         'unique',
       ]
-      const hedSchemas = await hedSchemaPromise
       const dictionaries = hedSchemas.baseSchema.attributes.tagAttributes
       assert.hasAllKeys(dictionaries, tagDictionaryKeys)
     })
 
-    it('should have unit dictionaries for all required unit attributes', async () => {
+    it('should have unit dictionaries for all required unit attributes', () => {
       const unitDictionaryKeys = ['SIUnit', 'unitSymbol']
-      const hedSchemas = await hedSchemaPromise
       const dictionaries = hedSchemas.baseSchema.attributes.unitAttributes
       assert.hasAllKeys(dictionaries, unitDictionaryKeys)
     })
 
-    it('should contain all of the required tags', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the required tags', () => {
       const requiredTags = ['event/category', 'event/description', 'event/label']
       const dictionariesRequiredTags = hedSchemas.baseSchema.attributes.tagAttributes['required']
       assert.hasAllKeys(dictionariesRequiredTags, requiredTags)
     })
 
-    it('should contain all of the positioned tags', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the positioned tags', () => {
       const positionedTags = ['event/category', 'event/description', 'event/label', 'event/long name']
       const dictionariesPositionedTags = hedSchemas.baseSchema.attributes.tagAttributes['position']
       assert.hasAllKeys(dictionariesPositionedTags, positionedTags)
     })
 
-    it('should contain all of the unique tags', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the unique tags', () => {
       const uniqueTags = ['event/description', 'event/label', 'event/long name']
       const dictionariesUniqueTags = hedSchemas.baseSchema.attributes.tagAttributes['unique']
       assert.hasAllKeys(dictionariesUniqueTags, uniqueTags)
     })
 
-    it('should contain all of the tags with default units', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the tags with default units', () => {
       const defaultUnitTags = {
         'attribute/blink/time shut/#': 's',
         'attribute/blink/duration/#': 's',
@@ -182,8 +176,7 @@ describe('HED schemas', () => {
       assert.deepStrictEqual(dictionariesDefaultUnitTags, defaultUnitTags)
     })
 
-    it('should contain all of the unit classes with their units and default units', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the unit classes with their units and default units', () => {
       const defaultUnits = {
         acceleration: 'm-per-s^2',
         currency: '$',
@@ -230,8 +223,7 @@ describe('HED schemas', () => {
       assert.deepStrictEqual(dictionariesAllUnits, allUnits, 'All units')
     })
 
-    it('should contain the correct (large) numbers of tags with certain attributes', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain the correct (large) numbers of tags with certain attributes', () => {
       const expectedAttributeTagCount = {
         isNumeric: 80,
         predicateType: 20,
@@ -259,8 +251,7 @@ describe('HED schemas', () => {
       )
     })
 
-    it('should identify if a tag has a certain attribute', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should identify if a tag has a certain attribute', () => {
       const testStrings = {
         value: 'Attribute/Location/Reference frame/Relative to participant/Azimuth/#',
         valueParent: 'Attribute/Location/Reference frame/Relative to participant/Azimuth',
@@ -341,30 +332,27 @@ describe('HED schemas', () => {
 
   describe('HED-3G schemas', () => {
     const localHedSchemaFile = 'tests/data/HED8.0.0.xml'
-    let hedSchemaPromise
+    let hedSchemas
 
-    beforeAll(() => {
+    beforeAll(async () => {
       const spec2 = new SchemaSpec('', '8.0.0', '', localHedSchemaFile)
       const specs = new SchemasSpec().addSchemaSpec(spec2)
-      hedSchemaPromise = buildSchemas(specs)
+      hedSchemas = await buildSchemas(specs)
     })
 
-    it('should contain all of the tag group tags', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the tag group tags', () => {
       const tagGroupTags = ['def-expand']
       const schemaTagGroupTags = hedSchemas.baseSchema.entries.tags.getEntriesWithBooleanAttribute('tagGroup')
       assert.hasAllKeys(schemaTagGroupTags, tagGroupTags)
     })
 
-    it('should contain all of the top-level tag group tags', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the top-level tag group tags', () => {
       const tagGroupTags = ['definition', 'event-context', 'onset', 'offset']
       const schemaTagGroupTags = hedSchemas.baseSchema.entries.tags.getEntriesWithBooleanAttribute('topLevelTagGroup')
       assert.hasAllKeys(schemaTagGroupTags, tagGroupTags)
     })
 
-    it('should contain all of the unit classes with their units and default units', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain all of the unit classes with their units and default units', () => {
       const defaultUnits = {
         accelerationUnits: 'm-per-s^2',
         angleUnits: 'radian',
@@ -412,8 +400,7 @@ describe('HED schemas', () => {
       }
     })
 
-    it('should contain the correct (large) numbers of tags with certain attributes', async () => {
-      const hedSchemas = await hedSchemaPromise
+    it('should contain the correct (large) numbers of tags with certain attributes', () => {
       const expectedAttributeTagCount = {
         requireChild: 7,
         takesValue: 88,

--- a/utils/__tests__/hed.spec.js
+++ b/utils/__tests__/hed.spec.js
@@ -185,12 +185,12 @@ describe('HED tag string utility functions', () => {
 
   describe('HED tag schema-based utility functions', () => {
     const localHedSchemaFile = 'tests/data/HED7.1.1.xml'
-    let hedSchemaPromise
+    let hedSchemas
 
-    beforeAll(() => {
+    beforeAll(async () => {
       const spec1 = new SchemaSpec('', '7.1.1', '', localHedSchemaFile)
       const specs = new SchemasSpec().addSchemaSpec(spec1)
-      hedSchemaPromise = buildSchemas(specs)
+      hedSchemas = await buildSchemas(specs)
     })
 
     it.skip('should strip valid units from a value', () => {
@@ -200,24 +200,22 @@ describe('HED tag string utility functions', () => {
       const invalidVolumeString = '200 cm'
       const currencyUnits = ['dollars', '$', 'points', 'fraction']
       const volumeUnits = ['m^3']
-      return hedSchemaPromise.then((hedSchemas) => {
-        const strippedDollarsString = hed.validateUnits(dollarsString, currencyUnits, hedSchemas.baseSchema.attributes)
-        const strippedVolumeString = hed.validateUnits(volumeString, volumeUnits, hedSchemas.baseSchema.attributes)
-        const strippedPrefixedVolumeString = hed.validateUnits(
-          prefixedVolumeString,
-          volumeUnits,
-          hedSchemas.baseSchema.attributes,
-        )
-        const strippedInvalidVolumeString = hed.validateUnits(
-          invalidVolumeString,
-          volumeUnits,
-          hedSchemas.baseSchema.attributes,
-        )
-        assert.sameOrderedMembers(strippedDollarsString, [true, true, '25.99'])
-        assert.sameOrderedMembers(strippedVolumeString, [true, true, '100'])
-        assert.sameOrderedMembers(strippedPrefixedVolumeString, [true, true, '100'])
-        assert.sameOrderedMembers(strippedInvalidVolumeString, [true, false, '200'])
-      })
+      const strippedDollarsString = hed.validateUnits(dollarsString, currencyUnits, hedSchemas.baseSchema.attributes)
+      const strippedVolumeString = hed.validateUnits(volumeString, volumeUnits, hedSchemas.baseSchema.attributes)
+      const strippedPrefixedVolumeString = hed.validateUnits(
+        prefixedVolumeString,
+        volumeUnits,
+        hedSchemas.baseSchema.attributes,
+      )
+      const strippedInvalidVolumeString = hed.validateUnits(
+        invalidVolumeString,
+        volumeUnits,
+        hedSchemas.baseSchema.attributes,
+      )
+      assert.sameOrderedMembers(strippedDollarsString, [true, true, '25.99'])
+      assert.sameOrderedMembers(strippedVolumeString, [true, true, '100'])
+      assert.sameOrderedMembers(strippedPrefixedVolumeString, [true, true, '100'])
+      assert.sameOrderedMembers(strippedInvalidVolumeString, [true, false, '200'])
     })
   })
 })


### PR DESCRIPTION
This removes the remaining direct uses of `Promise` in the tests in favor of `async`/`await`, except for one set that should not be converted.