### PR TITLE
Fix XML file transformation

### DIFF
--- a/fileTransformer.js
+++ b/fileTransformer.js
@@ -1,8 +1,10 @@
+const normalizeEOL = (str) => str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
 export default {
   process(sourceText, sourcePath, options) {
-    sourceText = sourceText.replace(/"/g, '\\"').replace(/\n/g, '\\n')
+    sourceText = normalizeEOL(sourceText)
     return {
-      code: `module.exports = "${sourceText}";`,
+      code: `module.exports = ${JSON.stringify(sourceText)};`,
     }
   },
 }


### PR DESCRIPTION
This fixes XML file transformation on Windows by converting the Windows-style line endings to Unix-style line endings. It also streamlines the replacements by using `JSON.stringify()`.