### PR TITLE
Fix duplicate tag check

### DIFF
--- a/parser/parsedHedGroup.js
+++ b/parser/parsedHedGroup.js
@@ -476,15 +476,12 @@ export class ParsedHedGroup extends ParsedHedSubstring {
    * @yields {ParsedHedTag[]} The subgroups of this tag group.
    */
   *subGroupArrayIterator() {
-    const currentGroup = []
     for (const innerTag of this.tags) {
-      if (innerTag instanceof ParsedHedTag) {
-        currentGroup.push(innerTag)
-      } else if (innerTag instanceof ParsedHedGroup) {
+      if (innerTag instanceof ParsedHedGroup) {
         yield* innerTag.subGroupArrayIterator()
       }
     }
-    yield currentGroup
+    yield this.tags
   }
 
   /**

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -266,7 +266,7 @@ describe('HED string and event validation', () => {
        *
        * @param {Object<string, string>} testStrings A mapping of test strings.
        * @param {Object<string, Issue[]>} expectedIssues The expected issues for each test string.
-       * @param {function(HedValidator, ParsedHedTag[]): void} testFunction A test-specific function that executes the required validation check.
+       * @param {function(HedValidator, ParsedHedSubstring[]): void} testFunction A test-specific function that executes the required validation check.
        * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
        */
       const validatorSyntactic = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
@@ -279,7 +279,7 @@ describe('HED string and event validation', () => {
                 testFunction(validator, subGroup)
               }
             }
-            testFunction(validator, validator.parsedString.topLevelTags)
+            testFunction(validator, validator.parsedString.parseTree)
           },
           testOptions,
         )
@@ -287,18 +287,26 @@ describe('HED string and event validation', () => {
 
       it('should not contain duplicates', () => {
         const testStrings = {
-          //topLevelDuplicate: 'Event/Category/Experimental stimulus,Event/Category/Experimental stimulus',
-          groupDuplicate:
-            'Item/Object/Vehicle/Train,(Event/Category/Experimental stimulus,Attribute/Visual/Color/Purple,Event/Category/Experimental stimulus)',
-          nestedGroupDuplicate:
-            'Item/Object/Vehicle/Train,(Attribute/Visual/Color/Purple,(Event/Category/Experimental stimulus,Event/Category/Experimental stimulus))',
           noDuplicate: 'Event/Category/Experimental stimulus,Item/Object/Vehicle/Train,Attribute/Visual/Color/Purple',
           legalDuplicate: 'Item/Object/Vehicle/Train,(Item/Object/Vehicle/Train,Event/Category/Experimental stimulus)',
           nestedLegalDuplicate:
             '(Item/Object/Vehicle/Train,(Item/Object/Vehicle/Train,Event/Category/Experimental stimulus))',
           legalDuplicateDifferentValue: '(Attribute/Language/Unit/Word/Brain,Attribute/Language/Unit/Word/Study)',
+          twoNonDuplicateGroups: '(Red, Blue, (Green)), (Red, Blue, ((Green)))',
+          //topLevelDuplicate: 'Event/Category/Experimental stimulus,Event/Category/Experimental stimulus',
+          groupDuplicate:
+            'Item/Object/Vehicle/Train,(Event/Category/Experimental stimulus,Attribute/Visual/Color/Purple,Event/Category/Experimental stimulus)',
+          nestedGroupDuplicate:
+            'Item/Object/Vehicle/Train,(Attribute/Visual/Color/Purple,(Event/Category/Experimental stimulus,Event/Category/Experimental stimulus))',
+          twoDuplicateGroups: '(Red, Blue, (Green)), (Red, Blue, (Green))',
+          repeatedGroup: '(Red, (Blue, Green, (Yellow)), Red, (Blue, Green, (Yellow)))',
         }
         const expectedIssues = {
+          noDuplicate: [],
+          legalDuplicate: [],
+          nestedLegalDuplicate: [],
+          legalDuplicateDifferentValue: [],
+          twoNonDuplicateGroups: [],
           topLevelDuplicate: [
             generateIssue('duplicateTag', {
               tag: 'Event/Category/Experimental stimulus',
@@ -323,10 +331,28 @@ describe('HED string and event validation', () => {
               tag: 'Event/Category/Experimental stimulus',
             }),
           ],
-          noDuplicate: [],
-          legalDuplicate: [],
-          nestedLegalDuplicate: [],
-          legalDuplicateDifferentValue: [],
+          twoDuplicateGroups: [
+            generateIssue('duplicateTag', {
+              tag: '(Red, Blue, (Green))',
+            }),
+            generateIssue('duplicateTag', {
+              tag: '(Red, Blue, (Green))',
+            }),
+          ],
+          repeatedGroup: [
+            generateIssue('duplicateTag', {
+              tag: 'Red',
+            }),
+            generateIssue('duplicateTag', {
+              tag: 'Red',
+            }),
+            generateIssue('duplicateTag', {
+              tag: '(Blue, Green, (Yellow))',
+            }),
+            generateIssue('duplicateTag', {
+              tag: '(Blue, Green, (Yellow))',
+            }),
+          ],
         }
         validatorSyntactic(testStrings, expectedIssues, (validator, tagLevel) => {
           validator.checkForDuplicateTags(tagLevel)
@@ -593,7 +619,7 @@ describe('HED string and event validation', () => {
          *
          * @param {Object<string, string>} testStrings A mapping of test strings.
          * @param {Object<string, Issue[]>} expectedIssues The expected issues for each test string.
-         * @param {function(HedValidator, ParsedHedTag[]): void} testFunction A test-specific function that executes the required validation check.
+         * @param {function(HedValidator, ParsedHedSubstring[]): void} testFunction A test-specific function that executes the required validation check.
          * @param {Object<string, boolean>?} testOptions Any needed custom options for the validator.
          */
         const validatorSemantic = function (testStrings, expectedIssues, testFunction, testOptions = {}) {
@@ -606,7 +632,7 @@ describe('HED string and event validation', () => {
                   testFunction(validator, subGroup)
                 }
               }
-              testFunction(validator, validator.parsedString.topLevelTags)
+              testFunction(validator, validator.parsedString.parseTree)
             },
             testOptions,
           )

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -707,28 +707,6 @@ describe('HED string and event validation', () => {
           )
         })
       })
-
-      describe('HED Strings', () => {
-        const validator = function (testStrings, expectedIssues, expectValuePlaceholderString = false) {
-          for (const [testStringKey, testString] of Object.entries(testStrings)) {
-            assert.property(expectedIssues, testStringKey, testStringKey + ' is not in expectedIssues')
-            const [, testIssues] = hed.validateHedString(testString, hedSchemas, true, expectValuePlaceholderString)
-            assert.sameDeepMembers(testIssues, expectedIssues[testStringKey], testString)
-          }
-        }
-
-        it('should skip tag group-level checks', () => {
-          const testStrings = {
-            duplicate: 'Item/Object/Vehicle/Train,Item/Object/Vehicle/Train',
-            multipleUnique: 'Event/Description/Rail vehicles,Event/Description/Locomotive-pulled or multiple units',
-          }
-          const expectedIssues = {
-            duplicate: [],
-            multipleUnique: [],
-          }
-          return validator(testStrings, expectedIssues)
-        })
-      })
     })
 
     describe('Pre-v7.1.0 HED schemas', () => {

--- a/validator/event/validator.js
+++ b/validator/event/validator.js
@@ -52,6 +52,7 @@ export class HedValidator {
   validateStringLevel() {
     this.options.isEventLevel = false
     this.validateIndividualHedTags()
+    this.validateHedTagLevels()
     this.validateHedTagGroups()
   }
 
@@ -99,7 +100,7 @@ export class HedValidator {
         this.validateHedTagLevel(subGroup)
       }
     }
-    this.validateHedTagLevel(this.parsedString.topLevelTags)
+    this.validateHedTagLevel(this.parsedString.parseTree)
   }
 
   /**
@@ -174,8 +175,9 @@ export class HedValidator {
    * Check for multiple instances of a unique tag.
    */
   checkForMultipleUniqueTags(tagList) {
+    const actualTagList = tagList.filter((tagOrGroup) => tagOrGroup instanceof ParsedHedTag)
     this._checkForTagAttribute(uniqueType, (uniqueTagPrefix) => {
-      if (tagList.filter((tag) => tag.formattedTag.startsWith(uniqueTagPrefix)).length > 1) {
+      if (actualTagList.filter((tag) => tag.formattedTag.startsWith(uniqueTagPrefix)).length > 1) {
         this.pushIssue('multipleUniqueTags', {
           tag: uniqueTagPrefix,
         })


### PR DESCRIPTION
This PR fixes the duplicate tag check. There were two issues. First, the subgroup array iterator in `ParsedTagGroup` was only returning the tags, excluding any groups. Also, only the top-level tags (not groups) were checked. Both were fixed, and the ensuing issue with the unique tag check was also mitigated. The JSON spec tests for duplicate tags were ported to the main JavaScript testcases for verification.

In order to make the sidecar tests pass, tag level validation (duplicate and unique tags) were moved up to string-level validation.