### PR TITLE
Fix bug with tag group equivalence that was causing tests to fail

### DIFF
--- a/bids/validator/bidsHedTsvValidator.js
+++ b/bids/validator/bidsHedTsvValidator.js
@@ -322,7 +322,7 @@ export class BidsHedTsvParser {
     const columnSpliceMapping = new Map()
 
     for (const [columnName, columnValue] of rowCells.entries()) {
-      if (columnValue === 'n/a') {
+      if (columnValue === 'n/a' || columnValue === '') {
         columnSpliceMapping.set(columnName, null)
         continue
       }

--- a/parser/parsedHedGroup.js
+++ b/parser/parsedHedGroup.js
@@ -451,7 +451,11 @@ export class ParsedHedGroup extends ParsedHedSubstring {
     if (!(other instanceof ParsedHedGroup)) {
       return false
     }
-    return differenceWith(this.tags, other.tags, (ours, theirs) => ours.equivalent(theirs)).length === 0
+    const equivalence = (ours, theirs) => ours.equivalent(theirs)
+    return (
+      differenceWith(this.tags, other.tags, equivalence).length === 0 &&
+      differenceWith(other.tags, this.tags, equivalence).length === 0
+    )
   }
 
   /**

--- a/spec_tests/jsonTests.spec.js
+++ b/spec_tests/jsonTests.spec.js
@@ -21,7 +21,7 @@ const skippedErrors = {
 }
 const readFileSync = fs.readFileSync
 const test_file_name = 'javascript_tests.json'
-//const test_file_name = 'temp3.json';
+//const test_file_name = 'temp3.json'
 
 function comboListToStrings(items) {
   const comboItems = []


### PR DESCRIPTION
This PR fixes a bug with tag group equivalence determination that was caused by the set difference function call only being made in one direction. This fixes the tests broken by the merging of #192 and #193. It also deletes a semicolon from the commented-out auxiliary spec file line.