### PR TITLE
Throw errors from ParsedHedTag constructors instead of using field

### DIFF
--- a/parser/parsedHedTag.js
+++ b/parser/parsedHedTag.js
@@ -317,7 +317,9 @@ export class ParsedHed3Tag extends ParsedHedTag {
   _convertTag(hedSchemas, hedString, tagSpec) {
     const hed3ValidCharacters = /^[^{}[\]()~,\0\t]+$/
     if (!hed3ValidCharacters.test(this.originalTag)) {
-      throw new Error('The parser failed to properly remove an illegal or special character.')
+      IssueError.generateAndThrow('internalConsistencyError', {
+        message: 'The parser failed to properly remove an illegal or special character.',
+      })
     }
 
     const schemaName = tagSpec.library
@@ -325,18 +327,14 @@ export class ParsedHed3Tag extends ParsedHedTag {
     if (this.schema === undefined) {
       this.canonicalTag = this.originalTag
       if (schemaName !== '') {
-        throw new IssueError(
-          generateIssue('unmatchedLibrarySchema', {
-            tag: this.originalTag,
-            library: schemaName,
-          }),
-        )
+        IssueError.generateAndThrow('unmatchedLibrarySchema', {
+          tag: this.originalTag,
+          library: schemaName,
+        })
       } else {
-        throw new IssueError(
-          generateIssue('unmatchedBaseSchema', {
-            tag: this.originalTag,
-          }),
-        )
+        IssueError.generateAndThrow('unmatchedBaseSchema', {
+          tag: this.originalTag,
+        })
       }
     }
 

--- a/tests/bids.spec.js
+++ b/tests/bids.spec.js
@@ -155,7 +155,6 @@ describe('BIDS datasets', () => {
         tag: 'Speed/300 miles',
         unitClassUnits: legalSpeedUnits.sort().join(','),
       })
-      const converterMaglevError = generateIssue('invalidTag', { tag: 'Maglev' })
       const maglevError = generateIssue('invalidTag', { tag: 'Maglev' })
       const maglevWarning = generateIssue('extension', { tag: 'Train/Maglev' })
       const expectedIssues = {
@@ -164,7 +163,6 @@ describe('BIDS datasets', () => {
           BidsHedIssue.fromHedIssue(cloneDeep(speedIssue), badDatasets[0].file, { tsvLine: 2 }),
           BidsHedIssue.fromHedIssue(cloneDeep(maglevWarning), badDatasets[1].file, { tsvLine: 2 }),
           BidsHedIssue.fromHedIssue(cloneDeep(speedIssue), badDatasets[2].file, { tsvLine: 3 }),
-          BidsHedIssue.fromHedIssue(converterMaglevError, badDatasets[3].file, { tsvLine: 2 }),
           BidsHedIssue.fromHedIssue(cloneDeep(maglevError), badDatasets[3].file, { tsvLine: 2 }),
           BidsHedIssue.fromHedIssue(cloneDeep(speedIssue), badDatasets[3].file, { tsvLine: 3 }),
           BidsHedIssue.fromHedIssue(cloneDeep(maglevWarning), badDatasets[4].file, { tsvLine: 2 }),

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -61,10 +61,6 @@ describe('HED dataset validation', () => {
             tag: testDatasets.multipleInvalid[0],
             unitClassUnits: legalTimeUnits.sort().join(','),
           }),
-          // TODO: Duplication temporary
-          generateValidationIssue('invalidTag', {
-            tag: testDatasets.multipleInvalid[1],
-          }),
           generateValidationIssue('invalidTag', { tag: testDatasets.multipleInvalid[1] }),
         ],
       }
@@ -113,10 +109,6 @@ describe('HED dataset validation', () => {
           generateValidationIssue('unitClassInvalidUnit', {
             tag: testDatasets.multipleInvalid[0],
             unitClassUnits: legalTimeUnits.sort().join(','),
-          }),
-          // TODO: Duplication temporary
-          generateValidationIssue('invalidTag', {
-            tag: testDatasets.multipleInvalid[1],
           }),
           generateValidationIssue('invalidTag', { tag: testDatasets.multipleInvalid[1] }),
         ],

--- a/tests/stringParser.spec.js
+++ b/tests/stringParser.spec.js
@@ -341,14 +341,14 @@ describe('HED string parsing', () => {
           'Property/Sensory-property/Sensory-attribute/Visual-attribute/Color/RGB-color/RGB-red/0.5',
           'Item/Object/Man-made-object/Vehicle/Car',
         ],
-        invalidTag: ['InvalidTag'],
-        invalidParentNode: ['Car/Train/Maglev'],
+        invalidTag: [],
+        invalidParentNode: [],
       }
       const expectedIssues = {
         simple: {},
         groupAndTag: {},
         invalidTag: {
-          conversion: [generateIssue('invalidTag', { tag: expectedResults.invalidTag[0] })],
+          conversion: [generateIssue('invalidTag', { tag: testStrings.invalidTag })],
         },
         invalidParentNode: {
           conversion: [

--- a/utils/hedData.js
+++ b/utils/hedData.js
@@ -35,13 +35,15 @@ export const mergeParsingIssues = function (previousIssues, currentIssues) {
 export const getParsedParentTags = function (hedSchemas, shortTag) {
   const parentTags = new Map()
   for (const [schemaNickname, schema] of hedSchemas.schemas) {
-    const parentTag = new ParsedHed3Tag(
-      new TagSpec(shortTag, 0, shortTag.length - 1, schemaNickname),
-      hedSchemas,
-      shortTag,
-    )
-    parentTags.set(schema, parentTag)
-    parentTag.conversionIssues = parentTag.conversionIssues.filter((issue) => issue.internalCode !== 'invalidTag')
+    try {
+      const parentTag = new ParsedHed3Tag(
+        new TagSpec(shortTag, 0, shortTag.length - 1, schemaNickname),
+        hedSchemas,
+        shortTag,
+      )
+      parentTags.set(schema, parentTag)
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
   }
   return parentTags
 }

--- a/validator/hed2/parser/parsedHed2Tag.js
+++ b/validator/hed2/parser/parsedHed2Tag.js
@@ -30,7 +30,6 @@ export class ParsedHed2Tag extends ParsedHedTag {
   // eslint-disable-next-line no-unused-vars
   _convertTag(hedString, hedSchemas, schemaName) {
     this.canonicalTag = this.originalTag
-    this.conversionIssues = []
     this.schema = hedSchemas.standardSchema
   }
 


### PR DESCRIPTION
Also fix testcases to remove now-deleted duplicate messages and bad outputs.