### PR TITLE
Move HED 3 requireChild testing to TagConverter and refactor that class

### DIFF
--- a/parser/converter.js
+++ b/parser/converter.js
@@ -109,9 +109,9 @@ export default class TagConverter {
     return childTag
   }
 
-  _getSchemaTag(i, trimLeft = false) {
+  _getSchemaTag(i) {
     let tagLevel = this.tagLevels[i].toLowerCase()
-    if (trimLeft) {
+    if (i === 0) {
       tagLevel = tagLevel.trimLeft()
     }
     if (tagLevel === '' || tagLevel !== tagLevel.trim()) {

--- a/parser/converter.js
+++ b/parser/converter.js
@@ -100,7 +100,7 @@ export default class TagConverter {
         parentTag: parentTag.longName,
       })
     }
-    if (childTag !== undefined && parentTag && (childTag.parent === undefined || childTag.parent !== parentTag)) {
+    if (childTag !== undefined && i > 0 && (childTag.parent === undefined || childTag.parent !== parentTag)) {
       IssueError.generateAndThrow('invalidParentNode', {
         tag: this.tagLevels[i],
         parentTag: childTag.longName,

--- a/parser/parsedHedGroup.js
+++ b/parser/parsedHedGroup.js
@@ -4,7 +4,7 @@ import { generateIssue, IssueError } from '../common/issues/issues'
 import { getParsedParentTags } from '../utils/hedData'
 import { getTagName } from '../utils/hedStrings'
 import ParsedHedSubstring from './parsedHedSubstring'
-import { ParsedHedTag } from './parsedHedTag'
+import { ParsedHed3Tag, ParsedHedTag } from './parsedHedTag'
 import ParsedHedColumnSplice from './parsedHedColumnSplice'
 
 /**
@@ -73,13 +73,12 @@ export class ParsedHedGroup extends ParsedHedSubstring {
     if (!hedSchemas.isHed3) {
       return undefined
     }
-    const parsedTags = getParsedParentTags(hedSchemas, shortTag)
     const tags = group.tags.filter((tag) => {
-      if (!(tag instanceof ParsedHedTag)) {
+      if (!(tag instanceof ParsedHed3Tag)) {
         return false
       }
-      const parsedTag = parsedTags.get(tag.schema)
-      return tag.isDescendantOf(parsedTag)
+      const schemaTag = tag.schemaTag
+      return schemaTag.name === shortTag
     })
     switch (tags.length) {
       case 0:

--- a/parser/parsedHedTag.js
+++ b/parser/parsedHedTag.js
@@ -379,31 +379,32 @@ export class ParsedHed3Tag extends ParsedHedTag {
   }
 
   /**
-   * Get the value-taking form of this tag.
+   * Get the schema tag object for this tag.
    *
-   * @returns {string} The value-taking form of this tag.
+   * @returns {SchemaTag} The schema tag object for this tag.
    */
-  get takesValueFormattedTag() {
-    return this._memoize('takesValueFormattedTag', () => {
-      const takesValueType = 'takesValue'
-      for (const ancestor of ParsedHedTag.ancestorIterator(this.formattedTag)) {
-        const takesValueTag = replaceTagNameWithPound(ancestor)
-        if (this.schema?.tagHasAttribute(takesValueTag, takesValueType)) {
-          return takesValueTag
-        }
+  get schemaTag() {
+    return this._memoize('takesValueTag', () => {
+      if (this._schemaTag instanceof SchemaValueTag) {
+        return this._schemaTag.parent
+      } else {
+        return this._schemaTag
       }
-      return null
     })
   }
 
   /**
    * Get the schema tag object for this tag's value-taking form.
    *
-   * @returns {SchemaTag} The schema tag object for this tag's value-taking form.
+   * @returns {SchemaValueTag} The schema tag object for this tag's value-taking form.
    */
   get takesValueTag() {
     return this._memoize('takesValueTag', () => {
-      return this._schemaTag
+      if (this._schemaTag instanceof SchemaValueTag) {
+        return this._schemaTag
+      } else {
+        return undefined
+      }
     })
   }
 
@@ -414,7 +415,7 @@ export class ParsedHed3Tag extends ParsedHedTag {
    */
   get takesValue() {
     return this._memoize('takesValue', () => {
-      return this.takesValueFormattedTag !== null
+      return this.takesValueTag !== undefined
     })
   }
 

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -1235,6 +1235,32 @@ describe('HED string and event validation', () => {
           validator.checkForMissingDefinitions(tag, 'Def-expand')
         })
       })
+
+      it('should have a child when required', () => {
+        const testStrings = {
+          noRequiredChild: 'Red',
+          hasRequiredChild: 'Label/Blah',
+          missingChild: 'Label',
+          longMissingChild: 'Property/Informational-property/Label',
+        }
+        const expectedIssues = {
+          noRequiredChild: [],
+          hasRequiredChild: [],
+          missingChild: [
+            generateIssue('childRequired', {
+              tag: testStrings.missingChild,
+            }),
+          ],
+          longMissingChild: [
+            generateIssue('childRequired', {
+              tag: testStrings.longMissingChild,
+            }),
+          ],
+        }
+        return validatorSemantic(testStrings, expectedIssues, (validator) => {
+          validator.validateEventLevel()
+        })
+      })
     })
 
     describe('HED Tag Groups', () => {

--- a/validator/event/hed3.js
+++ b/validator/event/hed3.js
@@ -396,9 +396,6 @@ export class Hed3Validator extends HedValidator {
     const definitionShortTag = 'Definition'
     const defExpandShortTag = 'Def-expand'
     const defShortTag = 'Def'
-    const definitionParentTags = getParsedParentTags(this.hedSchemas, definitionShortTag)
-    const defExpandParentTags = getParsedParentTags(this.hedSchemas, defExpandShortTag)
-    const defParentTags = getParsedParentTags(this.hedSchemas, defShortTag)
 
     const definitionName = tagGroup.definitionNameAndValue
 
@@ -421,14 +418,10 @@ export class Hed3Validator extends HedValidator {
           })
         }
         for (const innerTag of tag.tagIterator()) {
-          const nestedDefinitionParentTags = [
-            ...definitionParentTags.values(),
-            ...defExpandParentTags.values(),
-            ...defParentTags.values(),
-          ]
+          const nestedDefinitionParentTags = [definitionShortTag, defExpandShortTag, defShortTag]
           if (
             nestedDefinitionParentTags.some((parentTag) => {
-              return innerTag.isDescendantOf(parentTag)
+              return innerTag.schemaTag?.name === parentTag
             })
           ) {
             this.pushIssue('nestedDefinition', {
@@ -441,7 +434,7 @@ export class Hed3Validator extends HedValidator {
           definition: definitionName,
           column: tag.originalTag,
         })
-      } else if (!tag.isDescendantOf(definitionParentTags.get(tag.schema))) {
+      } else if (tag.schemaTag?.name !== 'Definition') {
         this.pushIssue('illegalDefinitionGroupTag', {
           tag: tag,
           definition: definitionName,
@@ -453,12 +446,11 @@ export class Hed3Validator extends HedValidator {
   /**
    * Check for missing HED 3 definitions.
    *
-   * @param {ParsedHedTag} tag The HED tag.
+   * @param {ParsedHed3Tag} tag The HED tag.
    * @param {string} defShortTag The short tag to check for.
    */
   checkForMissingDefinitions(tag, defShortTag = 'Def') {
-    const defParentTags = getParsedParentTags(this.hedSchemas, defShortTag)
-    if (!tag.isDescendantOf(defParentTags.get(tag.schema))) {
+    if (tag.schemaTag?.name !== defShortTag) {
       return
     }
     const defName = ParsedHedGroup.findDefinitionName(tag.canonicalTag, defShortTag)

--- a/validator/event/validator.js
+++ b/validator/event/validator.js
@@ -5,7 +5,6 @@ import { Schemas } from '../../common/schema/types'
 const NAME_CLASS_REGEX = /^[\w\-\u0080-\uFFFF]+$/
 const uniqueType = 'unique'
 const requiredType = 'required'
-const requireChildType = 'requireChild'
 const specialTags = require('./specialTags.json')
 
 // Validation tests
@@ -84,7 +83,6 @@ export class HedValidator {
     if (this.hedSchemas.generation > 0) {
       this.checkIfTagIsValid(tag, previousTag)
       this.checkIfTagUnitClassUnitsAreValid(tag)
-      this.checkIfTagRequiresChild(tag)
       if (!this.options.isEventLevel) {
         this.checkValueTagSyntax(tag)
       }
@@ -208,19 +206,6 @@ export class HedValidator {
    */
   // eslint-disable-next-line no-unused-vars
   _checkForTagAttribute(attribute, fn) {}
-
-  /**
-   * Check if a tag is missing a required child.
-   *
-   * @param {ParsedHedTag} tag The HED tag to be checked.
-   */
-  checkIfTagRequiresChild(tag) {
-    const invalid = tag.hasAttribute(requireChildType)
-    if (invalid) {
-      // If this tag has the "requireChild" attribute, then by virtue of even being in the dataset it is missing a required child.
-      this.pushIssue('childRequired', { tag: tag })
-    }
-  }
 
   /**
    * Check that the unit is valid for the tag's unit class.

--- a/validator/hed2/event/hed2Validator.js
+++ b/validator/hed2/event/hed2Validator.js
@@ -6,12 +6,22 @@ const clockTimeUnitClass = 'clockTime'
 const dateTimeUnitClass = 'dateTime'
 const timeUnitClass = 'time'
 
+const requireChildType = 'requireChild'
+
 /**
  * Hed2Validator class
  */
 export class Hed2Validator extends HedValidator {
   constructor(parsedString, hedSchemas, options) {
     super(parsedString, hedSchemas, options)
+  }
+
+  /**
+   * Validate an individual HED tag.
+   */
+  validateIndividualHedTag(tag, previousTag) {
+    super.validateIndividualHedTag(tag, previousTag)
+    this.checkIfTagRequiresChild(tag)
   }
 
   _checkForTagAttribute(attribute, fn) {
@@ -118,5 +128,18 @@ export class Hed2Validator extends HedValidator {
     }
     const hed2ValidValueCharacters = /^[-a-zA-Z0-9.$%^+_; :]+$/
     return hed2ValidValueCharacters.test(value)
+  }
+
+  /**
+   * Check if a tag is missing a required child.
+   *
+   * @param {ParsedHed2Tag} tag The HED tag to be checked.
+   */
+  checkIfTagRequiresChild(tag) {
+    const invalid = tag.hasAttribute(requireChildType)
+    if (invalid) {
+      // If this tag has the "requireChild" attribute, then by virtue of even being in the dataset it is missing a required child.
+      this.pushIssue('childRequired', { tag: tag })
+    }
   }
 }


### PR DESCRIPTION
This PR moves testing for the `requireChild` schema attribute in HED 3 to `TagConverter`. It also simplifies the conversion code.