### PR TITLE
Create and use setters for private fields in SchemaTag

### DIFF
--- a/schema/entries.js
+++ b/schema/entries.js
@@ -1,5 +1,6 @@
 import pluralize from 'pluralize'
 import Memoizer from '../utils/memoizer'
+import { IssueError } from '../common/issues/issues'
 
 pluralize.addUncountableRule('hertz')
 
@@ -847,11 +848,25 @@ export class SchemaTag extends SchemaEntryWithAttributes {
   }
 
   /**
-   * This tag's value-taking child.
+   * This tag's value-taking child tag.
    * @returns {SchemaValueTag}
    */
   get valueTag() {
     return this._valueTag
+  }
+
+  /**
+   * Set the tag's value-taking child tag.
+   * @param {SchemaValueTag} newValueTag The new value-taking child tag.
+   */
+  set valueTag(newValueTag) {
+    if (this._valueTag === undefined) {
+      this._valueTag = newValueTag
+    } else {
+      IssueError.generateAndThrow('internalError', {
+        message: `Attempted to set value tag for schema tag "${this.longName}" when it already has one.`,
+      })
+    }
   }
 
   /**
@@ -860,6 +875,20 @@ export class SchemaTag extends SchemaEntryWithAttributes {
    */
   get parent() {
     return this._parent
+  }
+
+  /**
+   * Set the tag's parent tag.
+   * @param {SchemaTag} newParent The new parent tag.
+   */
+  set parent(newParent) {
+    if (this._parent === undefined) {
+      this._parent = newParent
+    } else {
+      IssueError.generateAndThrow('internalError', {
+        message: `Attempted to set parent for schema tag ${this.longName} when it already has one.`,
+      })
+    }
   }
 
   /**

--- a/schema/parser.js
+++ b/schema/parser.js
@@ -418,11 +418,11 @@ export default class SchemaParser {
       const parentTagName = shortTags.get(tagElement.$parent)
 
       if (parentTagName) {
-        tagEntries.get(lc(tagName))._parent = tagEntries.get(lc(parentTagName))
+        tagEntries.get(lc(tagName)).parent = tagEntries.get(lc(parentTagName))
       }
 
       if (this.getElementTagName(tagElement) === '#') {
-        tagEntries.get(lc(parentTagName))._valueTag = tagEntries.get(lc(tagName))
+        tagEntries.get(lc(parentTagName)).valueTag = tagEntries.get(lc(tagName))
       }
     }
   }

--- a/schema/schemaMerger.js
+++ b/schema/schemaMerger.js
@@ -157,9 +157,9 @@ export default class PartneredSchemaMerger {
     }
     const destinationParentTag = this.destinationTags.getEntry(tag.parent?.name?.toLowerCase())
     if (destinationParentTag) {
-      newTag._parent = destinationParentTag
+      newTag.parent = destinationParentTag
       if (newTag instanceof SchemaValueTag) {
-        newTag.parent._valueTag = newTag
+        newTag.parent.valueTag = newTag
       }
     }
 


### PR DESCRIPTION
This will avoid directly setting private fields from outside code (poor coding practice) and ensure the fields are only set once.