### PR TITLE
Convert to TypeDoc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "allowJs": true,
+    "checkJs": true,
+    "outDir": "./dist",
+    "target": "es2017"
+  },
+  "include": [
+    "./*.js",
+    "./*.mjs",
+    "bids/**/*.js",
+    "common/**/*.js",
+    "parser/**/*.js",
+    "schema/**/*.js",
+    "spec_tests/**/*.js",
+    "tests/**/*.js",
+    "utils/**/*.js"
+  ]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,6 @@
+{
+  "entryPoints": ["./index.js"],
+  "out": "typedocs",
+  "includeVersion": true,
+  "excludeExternals": true
+}


### PR DESCRIPTION
This is the start of an eventual conversion to TypeDoc. It spectacularly fails right now.

TypeDoc is already installed as a dev dependency. To run, use `./node_modules/.bin/typedoc` in the repository root.