### PR TITLE
Remove "sphinx" dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "jsdoc": "^4.0.4",
         "prettier": "^3.2.5",
         "pretty-quick": "^4.0.0",
-        "sphinx": "^0.1.2",
         "typedoc": "^0.25.13",
         "typescript": "^5.4.5"
       },
@@ -5093,16 +5092,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/sphinx": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/sphinx/-/sphinx-0.1.2.tgz",
-      "integrity": "sha512-Z+LVXYEmAU19Tal7dupgmFEBI6KGsdIFdf3gq9R3CeQ4z6ImpjEFix938KAtoi/z1zUDHb4jphJBibbErusCnQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9297,12 +9286,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "sphinx": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/sphinx/-/sphinx-0.1.2.tgz",
-      "integrity": "sha512-Z+LVXYEmAU19Tal7dupgmFEBI6KGsdIFdf3gq9R3CeQ4z6ImpjEFix938KAtoi/z1zUDHb4jphJBibbErusCnQ==",
-      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "jsdoc": "^4.0.4",
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0",
-    "sphinx": "^0.1.2",
     "typedoc": "^0.25.13",
     "typescript": "^5.4.5"
   },


### PR DESCRIPTION
This "sphinx" (https://www.npmjs.com/package/sphinx) is entirely unrelated to the Sphinx used by Read the Docs, and it is thus unnecessary,