### PR TITLE
Ignore chai major version updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     target-branch: 'develop'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'chai'
+        update-types:
+          - 'version-update:semver-major'
   - package-ecosystem: 'gitsubmodule'
     directory: '/'
     target-branch: 'develop'


### PR DESCRIPTION
Chai v5 does not work with the current code, so we skip it here.