### PR TITLE
Implement static methods for creating BIDS file objects from BIDS dataset paths

### DIFF
--- a/src/bids/datasetParser.js
+++ b/src/bids/datasetParser.js
@@ -1,7 +1,4 @@
-import path from 'path'
-
 import { BidsJsonFile, BidsSidecar } from './types/json'
-import { readFile } from '../utils/files'
 
 /**
  * Parse a BIDS JSON file.
@@ -11,9 +8,7 @@ import { readFile } from '../utils/files'
  * @returns {Promise<BidsJsonFile>} The built JSON file object.
  */
 export async function parseBidsJsonFile(datasetRoot, relativePath) {
-  const [contents, fileObject] = await readBidsFile(datasetRoot, relativePath)
-  const jsonData = JSON.parse(contents)
-  return new BidsJsonFile(relativePath, fileObject, jsonData)
+  return BidsJsonFile.createFromBidsDatasetPath(datasetRoot, relativePath)
 }
 
 /**
@@ -24,21 +19,5 @@ export async function parseBidsJsonFile(datasetRoot, relativePath) {
  * @returns {Promise<BidsSidecar>} The built sidecar object.
  */
 export async function parseBidsSidecar(datasetRoot, relativePath) {
-  const [contents, fileObject] = await readBidsFile(datasetRoot, relativePath)
-  const jsonData = JSON.parse(contents)
-  return new BidsSidecar(relativePath, fileObject, jsonData)
+  return BidsSidecar.createFromBidsDatasetPath(datasetRoot, relativePath)
 }
-
-/**
- * Read a BIDS file.
- *
- * @param {string} datasetRoot The root path of the dataset.
- * @param {string} relativePath The relative path of the file within the dataset.
- * @returns {Promise<[string, {path: string}]>} The file contents and mocked BIDS-type file object.
- */
-export async function readBidsFile(datasetRoot, relativePath) {
-  const filePath = path.join(datasetRoot, relativePath)
-  const fileObject = { path: filePath }
-  return [await readFile(filePath), fileObject]
-}
-

--- a/src/bids/types/file.js
+++ b/src/bids/types/file.js
@@ -1,5 +1,8 @@
+import path from 'path'
+
 import { BidsHedIssue } from './issues'
 import { generateIssue } from '../../issues/issues'
+import { readFile } from '../../utils/files'
 
 /**
  * A BIDS file.
@@ -38,12 +41,16 @@ export class BidsFile {
   }
 
   /**
-   * Whether this is a TSV file timeline file.
+   * Read a BIDS file.
    *
-   * @returns {boolean}
+   * @param {string} datasetRoot The root path of the dataset.
+   * @param {string} relativePath The relative path of the file within the dataset.
+   * @returns {Promise<[string, {path: string}]>} The file contents and mocked BIDS-type file object.
    */
-  get isTimelineFile() {
-    return false
+  static async readBidsFileFromDatasetPath(datasetRoot, relativePath) {
+    const filePath = path.join(datasetRoot, relativePath)
+    const fileObject = { path: filePath }
+    return [await readFile(filePath), fileObject]
   }
 
   /**
@@ -75,6 +82,15 @@ export class BidsFile {
       // The low-level parsing throws exceptions with the issue encapsulated.
       return BidsHedIssue.fromHedIssues(error, this.file)
     }
+  }
+
+  /**
+   * Whether this is a TSV file timeline file.
+   *
+   * @returns {boolean}
+   */
+  get isTimelineFile() {
+    return false
   }
 
   /**

--- a/src/bids/types/json.js
+++ b/src/bids/types/json.js
@@ -30,6 +30,19 @@ export class BidsJsonFile extends BidsFile {
     super(name, file, BidsHedSidecarValidator)
     this.jsonData = jsonData
   }
+
+  /**
+   * Parse a BIDS JSON file from a BIDS dataset path.
+   *
+   * @param {string} datasetRoot The root path of the dataset.
+   * @param {string} relativePath The relative path of the file within the dataset.
+   * @returns {Promise<BidsJsonFile>} The built JSON file object.
+   */
+  static async createFromBidsDatasetPath(datasetRoot, relativePath) {
+    const [contents, fileObject] = await BidsFile.readBidsFileFromDatasetPath(datasetRoot, relativePath)
+    const jsonData = JSON.parse(contents)
+    return new BidsJsonFile(relativePath, fileObject, jsonData)
+  }
 }
 
 export class BidsSidecar extends BidsJsonFile {
@@ -96,6 +109,19 @@ export class BidsSidecar extends BidsJsonFile {
     this._setDefinitions(defManager)
     this._filterHedStrings()
     this._categorizeHedStrings()
+  }
+
+  /**
+   * Parse a BIDS sidecar from a BIDS dataset path.
+   *
+   * @param {string} datasetRoot The root path of the dataset.
+   * @param {string} relativePath The relative path of the file within the dataset.
+   * @returns {Promise<BidsSidecar>} The built sidecar object.
+   */
+  static async createFromBidsDatasetPath(datasetRoot, relativePath) {
+    const [contents, fileObject] = await BidsFile.readBidsFileFromDatasetPath(datasetRoot, relativePath)
+    const jsonData = JSON.parse(contents)
+    return new BidsSidecar(relativePath, fileObject, jsonData)
   }
 
   /**

--- a/src/bids/types/tsv.js
+++ b/src/bids/types/tsv.js
@@ -54,6 +54,32 @@ export class BidsTsvFile extends BidsFile {
     this._parseHedColumn()
   }
 
+  /**
+   * Parse a BIDS TSV file from a BIDS dataset path and sidecar.
+   *
+   * @param {string} datasetRoot The root path of the dataset.
+   * @param {string} relativePath The relative path of the file within the dataset.
+   * @param {BidsSidecar} sidecar The BIDS sidecar to use with this file.
+   * @returns {Promise<BidsTsvFile>} The built TSV file object.
+   */
+  static async createFromBidsDatasetPathAndSidecar(datasetRoot, relativePath, sidecar) {
+    const jsonData = sidecar.jsonData
+    return BidsTsvFile.createFromBidsDatasetPathAndJson(datasetRoot, relativePath, jsonData)
+  }
+
+  /**
+   * Parse a BIDS TSV file from a BIDS dataset path and sidecar JSON data.
+   *
+   * @param {string} datasetRoot The root path of the dataset.
+   * @param {string} relativePath The relative path of the file within the dataset.
+   * @param {object} jsonData The BIDS sidecar data to use with this file.
+   * @returns {Promise<BidsTsvFile>} The built TSV file object.
+   */
+  static async createFromBidsDatasetPathAndJson(datasetRoot, relativePath, jsonData) {
+    const [contents, fileObject] = await BidsFile.readBidsFileFromDatasetPath(datasetRoot, relativePath)
+    return new BidsTsvFile(relativePath, fileObject, contents, jsonData)
+  }
+
   _parseHedColumn() {
     const hedColumn = this.parsedTsv.get('HED')
     if (hedColumn === undefined) {


### PR DESCRIPTION
This moves most of the code from `bids/datasetParser.js` to static methods of `BidsFile` and its subclasses.