### PR TITLE
Exclude package.json and package-lock.json from codespell checks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = datasets,.git,*.pdf,*.svg,deprecated,*.xml,*.mediawiki,*.omn,datasets, docs/html/fonts, site/docs/html/scripts, site/Gemfile, site/Gemfile.lock
+skip = datasets,.git,*.pdf,*.svg,deprecated,*.xml,*.mediawiki,*.omn,datasets,docs/html/fonts,site/docs/html/scripts,site/Gemfile,site/Gemfile.lock,package.json,package-lock.json
 ignore-words-list = covert,hed,recuse,afterAll,hertzs,isnt,rouge,EACG


### PR DESCRIPTION
These files may contain "misspelled" names, but we don't care about those.