### PR TITLE
Move version spec parsing to Schema(s)Spec classes

### DIFF
--- a/src/bids/schema.js
+++ b/src/bids/schema.js
@@ -2,15 +2,11 @@
  * This module contains functions for building HED schemas for BIDS datasets.
  * @module schema
  */
-import castArray from 'lodash/castArray'
-import semver from 'semver'
 
 import { buildSchemas } from '../schema/init'
 import { IssueError } from '../issues/issues'
-import { SchemaSpec, SchemasSpec } from '../schema/specs'
+import { SchemasSpec } from '../schema/specs'
 import { BidsJsonFile } from './types/json'
-
-const alphabeticRegExp = new RegExp('^[a-zA-Z]+$')
 
 /**
  * Build a HED schema collection based on the defined BIDS schemas.
@@ -20,134 +16,10 @@ const alphabeticRegExp = new RegExp('^[a-zA-Z]+$')
  * @throws {IssueError} If the schema specification is invalid.
  */
 export async function buildBidsSchemas(datasetDescription) {
-  const schemasSpec = buildSchemasSpec(datasetDescription)
-  if (schemasSpec === null) {
-    return null
-  }
-  return buildSchemas(schemasSpec)
-}
-
-/**
- * Build a HED schema specification based on the defined BIDS schemas.
- *
- * @param {BidsJsonFile} datasetDescription The description of the BIDS dataset being validated.
- * @returns {SchemasSpec|null} The schema specification to be used to build the schemas, or null if the specification is missing.
- * @throws {IssueError} If the schema specification is invalid.
- */
-export function buildSchemasSpec(datasetDescription) {
-  if (datasetDescription.jsonData?.HEDVersion) {
-    return parseSchemasSpec(datasetDescription.jsonData.HEDVersion)
+  if (datasetDescription?.jsonData?.HEDVersion) {
+    const schemasSpec = SchemasSpec.parseVersionSpecs(datasetDescription.jsonData.HEDVersion)
+    return buildSchemas(schemasSpec)
   } else {
     return null
   }
-}
-
-/**
- * Parse a HED version specification into a schemas specification object.
- *
- * @param {string|string[]} hedVersion The HED version specification, can be a single version string or array of version strings.
- * @returns {SchemasSpec} A schemas specification object containing parsed schema specifications.
- * @throws {IssueError} If any schema specification is invalid.
- */
-export function parseSchemasSpec(hedVersion) {
-  const schemasSpec = new SchemasSpec()
-  const processVersion = castArray(hedVersion)
-  for (const schemaVersion of processVersion) {
-    const schemaSpec = parseSchemaSpec(schemaVersion)
-    schemasSpec.addSchemaSpec(schemaSpec)
-  }
-  return schemasSpec
-}
-
-/**
- * Parse a single schema specification string into a SchemaSpec object.
- *
- * @param {string} schemaVersion A schema version specification string (e.g., "nickname:library_version").
- * @returns {SchemaSpec} A schema specification object with parsed nickname, library, and version.
- * @throws {IssueError} If the schema specification format is invalid.
- */
-export function parseSchemaSpec(schemaVersion) {
-  const [nickname, schema] = splitPrefixAndSchema(schemaVersion)
-  const [library, version] = splitLibraryAndVersion(schema, schemaVersion)
-  return new SchemaSpec(nickname, version, library)
-}
-
-/**
- * Split a schema version string into prefix (nickname) and schema parts using colon delimiter.
- *
- * @param {string} schemaVersion The schema version string to split.
- * @returns {string[]} An array with [nickname, schema] where nickname may be empty string.
- * @throws {IssueError} If the schema specification format is invalid.
- */
-function splitPrefixAndSchema(schemaVersion) {
-  return splitVersionSegments(schemaVersion, schemaVersion, ':')
-}
-
-/**
- * Split a schema string into library and version parts using underscore delimiter.
- *
- * @param {string} schemaVersion The schema string to split (library_version format).
- * @param {string} originalVersion The original version string for error reporting.
- * @returns {string[]} An array with [library, version] where library may be empty string.
- * @throws {IssueError} If the schema specification format is invalid or version is not valid semver.
- */
-function splitLibraryAndVersion(schemaVersion, originalVersion) {
-  const [library, version] = splitVersionSegments(schemaVersion, originalVersion, '_')
-  if (!semver.valid(version)) {
-    IssueError.generateAndThrow('invalidSchemaSpecification', { spec: originalVersion })
-  }
-  return [library, version]
-}
-
-/**
- * Split a version string into two segments using the specified delimiter.
- *
- * @param {string} schemaVersion The version string to split.
- * @param {string} originalVersion The original version string for error reporting.
- * @param {string} splitCharacter The character to use as delimiter (':' or '_').
- * @returns {string[]} An array with [firstSegment, secondSegment] where firstSegment may be empty string.
- * @throws {IssueError} If the schema specification format is invalid or contains non-alphabetic characters in first segment.
- */
-function splitVersionSegments(schemaVersion, originalVersion, splitCharacter) {
-  const versionSplit = schemaVersion.split(splitCharacter)
-  const secondSegment = versionSplit.pop()
-  const firstSegment = versionSplit.pop()
-  if (versionSplit.length > 0) {
-    IssueError.generateAndThrow('invalidSchemaSpecification', { spec: originalVersion })
-  }
-  if (firstSegment !== undefined && !alphabeticRegExp.test(firstSegment)) {
-    IssueError.generateAndThrow('invalidSchemaSpecification', { spec: originalVersion })
-  }
-  return [firstSegment ?? '', secondSegment]
-}
-
-/**
- * Build HED schemas from a version specification string.
- *
- * @param {string} hedVersionString The HED version specification string (can contain comma-separated versions).
- * @returns {Promise<any>} A Promise that resolves to the built schemas.
- * @throws {Error} If the schema specification is invalid or schemas cannot be built.
- */
-export async function buildSchemasFromVersion(hedVersionString) {
-  let hedVersionValue = hedVersionString.trim()
-  if (hedVersionValue.includes(',')) {
-    hedVersionValue = hedVersionValue
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
-  }
-
-  const hedVersionSpec = new BidsJsonFile(
-    'HED schema input',
-    { path: 'HED schema version input' },
-    { HEDVersion: hedVersionValue },
-  )
-
-  const hedSchemas = await buildBidsSchemas(hedVersionSpec)
-
-  if (!hedSchemas) {
-    IssueError.generateAndThrow('invalidSchemaSpecification', { spec: hedVersionString })
-  }
-
-  return hedSchemas
 }

--- a/src/schema/init.js
+++ b/src/schema/init.js
@@ -6,6 +6,9 @@ import { setParent } from '../utils/xml2js'
 import SchemaParser from './parser'
 import PartneredSchemaMerger from './schemaMerger'
 import { Schema, Schemas } from './containers'
+import { IssueError } from '../issues/issues'
+import { splitStringTrimAndRemoveBlanks } from '../utils/string'
+import { SchemasSpec } from './specs'
 
 /**
  * Build a single schema container object from an XML file.
@@ -54,4 +57,18 @@ export async function buildSchemas(schemaSpecs) {
   const schemaObjects = schemaXmlData.map(buildSchemaObjects)
   const schemas = new Map(zip(schemaPrefixes, schemaObjects))
   return new Schemas(schemas)
+}
+
+/**
+ * Build HED schemas from a version specification string.
+ *
+ * @param {string} hedVersionString The HED version specification string (can contain comma-separated versions).
+ * @returns {Promise<Schemas>} A Promise that resolves to the built schemas.
+ * @throws {IssueError} If the schema specification is invalid or schemas cannot be built.
+ */
+export async function buildSchemasFromVersion(hedVersionString) {
+  hedVersionString ??= ''
+  const hedVersionSpecStrings = splitStringTrimAndRemoveBlanks(hedVersionString, ',')
+  const hedVersionSpecs = SchemasSpec.parseVersionSpecs(hedVersionSpecStrings)
+  return buildSchemas(hedVersionSpecs)
 }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,14 +1,28 @@
 /** String-related utility functions */
 
 /**
- * Get number of instances of an character in a string.
+ * Get number of instances of a character in a string.
  *
  * @param {string} string The string to search.
  * @param {string} characterToCount The character to search for.
  * @returns {number} The number of instances of the character in the string.
  */
-export const getCharacterCount = function (string, characterToCount) {
+export function getCharacterCount(string, characterToCount) {
   return string.split(characterToCount).length - 1
+}
+
+/**
+ * Split a string on a given delimiter, trim the substrings, and remove any blank substrings from the returned array.
+ *
+ * @param {string} string The string to split.
+ * @param {string} delimiter The delimiter on which to split.
+ * @returns {string[]} The split string with blanks removed and the remaining entries trimmed.
+ */
+export function splitStringTrimAndRemoveBlanks(string, delimiter = ',') {
+  return string
+    .split(delimiter)
+    .map((item) => item.trim())
+    .filter(Boolean)
 }
 
 /**
@@ -20,7 +34,7 @@ export const getCharacterCount = function (string, characterToCount) {
  * @param {(number|string)} keys The keys of the closure arguments.
  * @returns {function(...[*]): string} A closure to fill the string template.
  */
-export const stringTemplate = function (strings, ...keys) {
+export function stringTemplate(strings, ...keys) {
   return function (...values) {
     const dict = values[values.length - 1] ?? {}
     const result = [strings[0]]

--- a/tests/jsonTests/schemaSpecTests.spec.js
+++ b/tests/jsonTests/schemaSpecTests.spec.js
@@ -7,6 +7,7 @@ import { BidsJsonFile } from '../../src/bids'
 
 import { shouldRun } from '../testHelpers/testUtilities'
 import { schemaSpecTestData } from '../jsonTestData/schemaBuildTests.data'
+import { SchemasSpec } from '../../src/schema/specs'
 
 // Ability to select individual tests to run
 const skipMap = new Map()
@@ -29,17 +30,10 @@ describe('Schema validation', () => {
 
   describe.each(schemaSpecTestData)('$name : $description', ({ name, tests }) => {
     const validateSpec = function (test) {
-      const desc = new BidsJsonFile(
-        '/dataset_description.json',
-        {
-          path: '/dataset_description.json',
-        },
-        test.schemaVersion,
-      )
       let schemaSpec = null
       let caughtError = null
       try {
-        schemaSpec = buildSchemasSpec(desc, null)
+        schemaSpec = SchemasSpec.parseVersionSpecs(test.schemaVersion.HEDVersion)
       } catch (error) {
         caughtError = error
       }


### PR DESCRIPTION
This truncates the BIDS schema support to a single function. The new function generating schemas from version strings has been moved to `schema/init.js` (below `buildSchemas`).

I would prefer to rename `buildSchemasFromVersion` to `buildSchemasFromVersionString` if possible. The skipped tests need to be fixed or deleted, as the function they test no longer exists.