### PR TITLE
Fix export broken by #479

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ export {
   BidsSidecar,
   BidsHedIssue,
   buildBidsSchemas,
-  buildSchemasFromVersion,
   BidsFileAccessor,
   BidsDirectoryAccessor,
 } from './src/bids'
@@ -24,3 +23,5 @@ export { parseStandaloneString, parseHedString, parseHedStrings } from './src/pa
 
 // Export schema functions
 export { getLocalSchemaVersions } from './src/schema/config'
+
+export { buildSchemasFromVersion } from './src/schema/init'


### PR DESCRIPTION
The `buildSchemasFromVersion` function was moved to a different module in #479, but the import-export in `index.js` was not adjusted, breaking the Vite CI action. This fixes that.