### PR TITLE
Install current version of npm in publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,5 +16,7 @@ jobs:
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
+      - name: Update npm
+        run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --provenance --access public


### PR DESCRIPTION
This is required for OIDC support.