### PR TITLE
Release version 4.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hed-validator",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hed-validator",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hed-validator",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A JavaScript validator for HED (Hierarchical Event Descriptor) strings.",
   "main": "./dist/commonjs/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
This version should fix the remaining build issues by switching to Node's built-in `fetch` implementation, thereby requiring a bump in the Node dependency to 22.