### PR TITLE
Merge ESM builds

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -16,23 +16,11 @@ await esbuild.build({
   },
 })
 
-// ESM/Deno target build
-await esbuild.build({
-  entryPoints: [path.join(process.cwd(), 'index.js')],
-  loader: { '.xml': 'text' },
-  outdir: path.join(process.cwd(), 'dist', 'esm'),
-  bundle: true,
-  sourcemap: true,
-  format: 'esm',
-  external: ['pluralize'],
-  platform: 'node',
-})
-
 // Browser target build
 await esbuild.build({
   entryPoints: [path.join(process.cwd(), 'index.js')],
   loader: { '.xml': 'text' },
-  outdir: path.join(process.cwd(), 'dist', 'browser'),
+  outdir: path.join(process.cwd(), 'dist', 'esm'),
   bundle: true,
   sourcemap: true,
   format: 'esm',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-types": "npx tsx types/test.ts",
     "test-types-local": "node scripts/test-types-local.js",
     "test-types-local-windows": "powershell -ExecutionPolicy Bypass -File ./scripts/test-types-local-windows.ps1",
-    "test-types-local-unix": "bash ./scripts/test-types-local-unix.sh",
+    "test-types-local-unix": "sh ./scripts/test-types-local-unix.sh",
     "type-check": "tsc --noEmit",
     "coverage": "jest --coverage",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "node": "./dist/esm/index.js",
-      "import": "./dist/browser/index.js",
+      "import": "./dist/esm/index.js",
       "require": "./dist/commonjs/index.js"
     }
   },

--- a/scripts/test-types-local-unix.sh
+++ b/scripts/test-types-local-unix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Local TypeScript definition testing script
 echo "Building package..."

--- a/scripts/test-types-local.js
+++ b/scripts/test-types-local.js
@@ -19,7 +19,7 @@ function runScript() {
     args = ['-ExecutionPolicy', 'Bypass', '-File', './scripts/test-types-local-windows.ps1']
   } else {
     // Unix/Linux/macOS: Run bash script
-    command = 'bash'
+    command = 'sh'
     args = ['./scripts/test-types-local-unix.sh']
   }
 


### PR DESCRIPTION
This makes the browser build the sole ESM build, hopefully restoring the sanity of the 4.0.x series.